### PR TITLE
fix: wrap reset styles in @layer base and suppress canonical class lint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,7 @@
   "stylelint.validate": ["css", "typescript", "typescriptreact"],
   "js/ts.format.enable": false,
   "css.lint.unknownAtRules": "ignore",
+  "tailwindCSS.lint.suggestCanonicalClasses": "ignore",
   "editor.formatOnSave": true,
   "cSpell.words": [
     "cx-suite",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --webpack",
-    "build": "next build",
+    "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --webpack",
-    "build": "next build --webpack",
+    "build": "next build",
     "start": "next start",
     "lint": "eslint"
   },

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -41,7 +41,7 @@
     font-size: 1.4rem;
     line-height: 1.6;
     -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
 
   h1, h2, h3, h4, h5, h6, p, button, input, textarea, select {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -25,53 +25,52 @@
   text-size-adjust: none;
 }
 
-*, *::before, *::after {
-  box-sizing: border-box;
-  -webkit-tap-highlight-color: transparent;
-}
+@layer base {
+  *, *::before, *::after {
+    box-sizing: border-box;
+    -webkit-tap-highlight-color: transparent;
+  }
 
-body {
-  margin: 0;
-  padding: 0;
-  min-height: 100vh;
-  background-color: var(--color-bg-main);
-  color: var(--color-text-main);
-  
-  /* 폰트 및 기본 사이즈 */
-  font-family: var(--font-sans);
-  font-size: 1.4rem; /* 14px */
-  line-height: 1.6;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: antialiased;
-}
+  body {
+    margin: 0;
+    padding: 0;
+    min-height: 100vh;
+    background-color: var(--color-bg-main);
+    color: var(--color-text-main);
+    font-family: var(--font-sans);
+    font-size: 1.4rem;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: antialiased;
+  }
 
-/* 실무 리셋 코드 반영 */
-h1, h2, h3, h4, h5, h6, p, button, input, textarea, select {
-  margin: 0;
-  padding: 0;
-  font: inherit;
-  color: inherit;
-}
+  h1, h2, h3, h4, h5, h6, p, button, input, textarea, select {
+    margin: 0;
+    padding: 0;
+    font: inherit;
+    color: inherit;
+  }
 
-a {
-  text-decoration: none;
-  color: inherit;
-  cursor: pointer;
-}
+  a {
+    text-decoration: none;
+    color: inherit;
+    cursor: pointer;
+  }
 
-button {
-  cursor: pointer;
-  background: none;
-  border: none;
-}
+  button {
+    cursor: pointer;
+    background: none;
+    border: none;
+  }
 
-button:disabled {
-  cursor: not-allowed;
-}
+  button:disabled {
+    cursor: not-allowed;
+  }
 
-img, picture {
-  display: block;
-  max-width: 100%;
+  img, picture {
+    display: block;
+    max-width: 100%;
+  }
 }
 
 /* 커스텀 유틸리티 */
@@ -100,4 +99,4 @@ img, picture {
 }
 ::-webkit-scrollbar-thumb:hover {
   background: var(--color-accent);
-
+}


### PR DESCRIPTION
- Move all global reset styles into @layer base so Tailwind utility classes correctly override them (fixes padding/margin/font overrides)
- Set tailwindCSS.lint.suggestCanonicalClasses to ignore in VSCode settings to suppress w-5xl style suggestions (project uses numeric px-equivalent classes instead of named sizes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 업데이트 내역

* **Chores**
  * 개발 환경 설정을 조정하여 Tailwind CSS 관련 편집기 제안을 무시하도록 개선
  * 빌드 명령을 변경하여 번들링 동작을 조정

* **Style**
  * 전역 스타일의 기본 규칙을 레이어로 재구성하여 스타일 계층과 유지보수성 향상
  * 본문 렌더링 관련 폰트 스무딩 값 일부 조정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->