### PR TITLE
chore: add GitHub issue templates for bug, feature, and chore

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -18,3 +18,5 @@ body:
       label: Steps to Reproduce
       value: |
         1.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,20 @@
+name: "🐛 Bug"
+description: "Bug report"
+labels: ["type: bug"]
+assignees: ["sukki-codes"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      value: |
+        **Expected:** 
+        **Actual:** 
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      value: |
+        1.

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,18 @@
+name: "🔧 Chore / Docs"
+description: "Config, tooling, refactor, documentation"
+labels: ["type: chore"]
+assignees: ["sukki-codes"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: What & Why
+      placeholder: "무엇을 설정/변경하고 왜 필요한지"
+    validations:
+      required: true
+  - type: textarea
+    id: todo
+    attributes:
+      label: Checklist
+      value: |
+        - [ ]

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,18 @@
+name: "✨ Feature Request"
+description: "Propose a new feature or enhancement"
+labels: ["type: feature"]
+assignees: ["sukki-codes"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: What & Why
+      placeholder: "무엇을 왜 만드는지"
+    validations:
+      required: true
+  - type: textarea
+    id: todo
+    attributes:
+      label: Checklist
+      value: |
+        - [ ]


### PR DESCRIPTION
## Summary
- Add three GitHub issue templates: Bug, Feature Request, and Chore / Docs

## Templates
- **🐛 Bug** — captures expected vs. actual behavior and reproduction steps; auto-assigns `type: bug` label
- **✨ Feature Request** — captures what to build and why, with a task checklist; auto-assigns `type: feature` label
- **🔧 Chore / Docs** — covers config, tooling, refactoring, and documentation; auto-assigns `type: chore` label

## Test plan
- [ ] Verify all three templates appear when opening a new GitHub issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **유지보수**
  * GitHub 이슈 템플릿 3종 추가: 버그, 기능 요청, 유지보수/문서용 템플릿이 새로 도입되었습니다.
  * 각 템플릿은 구조화된 입력 폼(필수 텍스트 입력 및 체크리스트 포함)을 제공하여 이슈 작성과 관리를 일관되게 지원합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->