### PR TITLE
chore: add auto-assignee workflow for issues and pull requests

### DIFF
--- a/.github/workflows/auto-assignee.yml
+++ b/.github/workflows/auto-assignee.yml
@@ -1,0 +1,31 @@
+name: Auto Assignee
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto assign to sukki-codes
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const isIssue = context.payload.issue !== undefined;
+            const number = isIssue
+              ? context.payload.issue.number
+              : context.payload.pull_request.number;
+
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              assignees: ['sukki-codes'],
+            });

--- a/.github/workflows/auto-assignee.yml
+++ b/.github/workflows/auto-assignee.yml
@@ -7,7 +7,6 @@ on:
     types: [opened, reopened, ready_for_review]
 
 permissions:
-  pull-requests: write
   issues: write
 
 jobs:
@@ -23,9 +22,13 @@ jobs:
               ? context.payload.issue.number
               : context.payload.pull_request.number;
 
-            await github.rest.issues.addAssignees({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: number,
-              assignees: ['sukki-codes'],
-            });
+            try {
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: number,
+                assignees: ['sukki-codes'],
+              });
+            } catch (error) {
+              core.warning(`Auto-assign skipped: ${error.message}`);
+            }


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that automatically assigns `sukki-codes` to any newly opened issue or pull request (including reopened and ready-for-review events)

## How it works
- Triggers on `issues.opened` and `pull_request.opened / reopened / ready_for_review`
- Uses `actions/github-script@v8` to call the GitHub REST API for assignment
- Requires `pull-requests: write` and `issues: write` permissions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Chores**
  * 내부 워크플로우 자동화 개선으로 운영 효율성을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->