### PR TITLE
chore: add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,19 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    groups:
+      next-react:
+        patterns:
+          - "next"
+          - "react"
+          - "react-dom"
+    ignore:
+      - dependency-name: "next"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/auto-assignee.yml
+++ b/.github/workflows/auto-assignee.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   assign:


### PR DESCRIPTION
## Summary

- npm, github-actions 두 ecosystem에 대해 주간(weekly) 의존성 업데이트 자동화 설정
- PR 최대 10개로 제한

Closes #21

## Test plan

- [ ] GitHub > Insights > Dependency graph > Dependabot 탭에서 설정 확인
- [ ] 다음 weekly 스케줄 시 자동 PR 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 자동 업데이트 점검이 추가되어, 패키지 및 GitHub Actions 업데이트를 주간 단위로 확인합니다.
  * 한 번에 열리는 업데이트 PR 수가 최대 10개로 제한됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->