### PR TITLE
fix: clean up ESLint/Stylelint tooling issues found while prepping status-check

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,7 @@
   ],
   "stylelint.enable": true,
   "stylelint.configFile": ".stylelintrc.json",
-  "stylelint.validate": ["css", "typescript", "typescriptreact"],
+  "stylelint.validate": ["css"],
   "js/ts.format.enable": false,
   "css.lint.unknownAtRules": "ignore",
   "tailwindCSS.lint.suggestCanonicalClasses": "ignore",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -91,6 +91,9 @@ const eslintConfig = defineConfig([
     rules: {
       "react-hooks/rules-of-hooks": "error",
       "react-hooks/exhaustive-deps": "warn",
+      // https://github.com/facebook/react/issues/34743
+      // 2026-07-01 기준 아직 overly strict 논의가 진행중이라 off 처리하겠습니다.
+      "react-hooks/set-state-in-effect": "off",
     },
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.2.9",
+        "eslint-import-resolver-typescript": "^4.4.5",
         "eslint-plugin-perfectionist": "^5.9.1",
         "tailwindcss": "^4",
         "typescript": "^6"
@@ -3619,6 +3620,31 @@
         "node": "*"
       }
     },
+    "node_modules/eslint-import-context": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
+      "integrity": "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-tsconfig": "^4.10.1",
+        "stable-hash-x": "^0.2.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-context"
+      },
+      "peerDependencies": {
+        "unrs-resolver": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "unrs-resolver": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.10",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
@@ -3639,6 +3665,41 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.5.tgz",
+      "integrity": "sha512-nbE5XLph6TLtGYcu/U6e6ZVXyKBhbDWK5cLGk76eJ7NdZpwf1P9EFkpt1Z01mNZNrrilsAYWKH6zUkL4reoXbw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "eslint-import-context": "^0.1.8",
+        "get-tsconfig": "^4.10.1",
+        "is-bun-module": "^2.0.0",
+        "stable-hash-x": "^0.2.0",
+        "tinyglobby": "^0.2.14",
+        "unrs-resolver": "^1.7.11"
+      },
+      "engines": {
+        "node": "^16.17.0 || >=18.6.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-module-utils": {
@@ -5386,6 +5447,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -6440,6 +6508,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stable-hash-x": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
+      "integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -6624,6 +6702,49 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-4.5.0.tgz",
+      "integrity": "sha512-ZW2OvfeCXrNTbLakPUzjQG922EeGCOteFSVoek5DKStTh898wf7zgtuFlzQN8HfZCxC3Eh02yJVrRW51hADf+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^5.0.1",
+        "supports-color": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/has-flag": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-5.0.1.tgz",
+      "integrity": "sha512-CsNUt5x9LUdx6hnk/E2SZLsDyvfqANZSUq4+D3D8RzDJ2M+HDTIkF60ibS1vHaK55vzgiZw1bEPFG9yH7l33wA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.2.9",
+    "eslint-import-resolver-typescript": "^4.4.5",
     "eslint-plugin-perfectionist": "^5.9.1",
     "stylelint": "^17.14.0",
     "stylelint-config-standard": "^40.0.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,9 @@
 import { ReactNode } from 'react'
+
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import { ThemeProvider } from "next-themes";
+
 import Header from "@components/layout/Header";
 import "@styles/globals.css";
 
@@ -21,7 +23,7 @@ export default function RootLayout({
   children: ReactNode;
 }>) {
   return (
-    <html lang="ko" suppressHydrationWarning className={`${inter.variable} h-full`}>
+    <html suppressHydrationWarning className={`${inter.variable} h-full`} lang="ko">
       <body className="min-h-full flex flex-col bg-[color:var(--color-bg-main)] text-[color:var(--color-text-main)] transition-colors duration-300">
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
           <Header />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,13 +4,11 @@ export default function Home() {
   return (
     <main className="relative flex flex-1 flex-col items-center justify-center overflow-hidden px-15 py-80">
       <div className="dot-grid pointer-events-none absolute inset-0 opacity-60" />
-
       <div className="pointer-events-none absolute inset-0 overflow-hidden">
         <div className="absolute left-1/2 top-1/2 h-640 w-640 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[color:var(--color-accent)]/10 blur-[13rem]" />
         <div className="absolute -bottom-60 -left-40 h-350 w-500 rounded-full bg-[color:var(--color-secondary)]/15 blur-[9rem]" />
         <div className="absolute -right-40 top-0 h-280 w-340 rounded-full bg-[color:var(--color-accent)]/8 blur-[7rem]" />
       </div>
-
       <div className="relative z-10 flex flex-col items-center gap-20 text-center">
         <div className="flex items-center gap-8 rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-surface-card)]/80 px-16 py-7 shadow-[0_16px_50px_rgba(2,6,23,0.08)] backdrop-blur">
           <span className="h-7 w-7 animate-pulse rounded-full bg-[color:var(--color-accent)]" />
@@ -18,22 +16,19 @@ export default function Home() {
             Frontend Architect
           </span>
         </div>
-
         <h1 className="max-w-740 text-[4rem] font-bold leading-[1.12] tracking-[-0.02em] sm:text-[5.2rem] md:text-[6.4rem]">
           <span className="gradient-text">Systems</span>
           <br />
           <span className="text-[color:var(--color-text-main)]">that feel alive.</span>
         </h1>
-
         <p className="max-w-560 text-[1.6rem] leading-[1.8] text-[color:var(--color-text-sub)]">
           I design resilient frontend architecture, automation pipelines, and immersive digital experiences for ambitious products.
         </p>
-
         <div className="mt-5 flex flex-col gap-8 sm:flex-row">
-          <Link href="#projects" className="rounded-full bg-[color:var(--color-accent)] px-30 py-13 text-[1.4rem] font-semibold text-white shadow-[0_18px_45px_rgba(6,182,212,0.25)] transition-all duration-200 hover:-translate-y-0.5 hover:bg-[color:var(--color-accent-hover)]">
+          <Link className="rounded-full bg-[color:var(--color-accent)] px-30 py-13 text-[1.4rem] font-semibold text-white shadow-[0_18px_45px_rgba(6,182,212,0.25)] transition-all duration-200 hover:-translate-y-0.5 hover:bg-[color:var(--color-accent-hover)]" href="#projects">
             View Projects
           </Link>
-          <Link href="#approach" className="rounded-full border border-[color:var(--color-border)] px-30 py-13 text-[1.4rem] font-medium text-[color:var(--color-text-sub)] transition-all duration-200 hover:border-[color:var(--color-accent)]/30 hover:bg-[color:var(--color-surface-card)] hover:text-[color:var(--color-text-main)]">
+          <Link className="rounded-full border border-[color:var(--color-border)] px-30 py-13 text-[1.4rem] font-medium text-[color:var(--color-text-sub)] transition-all duration-200 hover:border-[color:var(--color-accent)]/30 hover:bg-[color:var(--color-surface-card)] hover:text-[color:var(--color-text-main)]" href="#approach">
             Explore Approach
           </Link>
         </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+
 import ThemeToggle from "@components/layout/ThemeToggle";
 
 const NAV_LINKS = [
@@ -9,18 +10,17 @@ export default function Header() {
   return (
     <header className="sticky top-0 z-50 w-full border-b border-[color:var(--color-border)] bg-[color:var(--color-surface-elevated)]/80 backdrop-blur-sm">
       <div className="mx-auto flex h-40 max-w-800 items-center justify-between px-15">
-        <Link href="/" className="text-[1.8rem] font-semibold tracking-tight text-[color:var(--color-text-main)]">
+        <Link className="text-[1.8rem] font-semibold tracking-tight text-[color:var(--color-text-main)]" href="/">
           Polio
         </Link>
-
         <div className="flex items-center gap-12">
           <nav>
             <ul className="flex items-center gap-15">
               {NAV_LINKS.map(({ label, href }) => (
                 <li key={href}>
                   <Link
-                    href={href}
                     className="text-[1.4rem] text-[color:var(--color-text-sub)] transition-colors hover:text-[color:var(--color-text-main)]"
+                    href={href}
                   >
                     {label}
                   </Link>
@@ -28,7 +28,6 @@ export default function Header() {
               ))}
             </ul>
           </nav>
-
           <ThemeToggle />
         </div>
       </div>

--- a/src/components/layout/ThemeToggle.tsx
+++ b/src/components/layout/ThemeToggle.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+
 import { useTheme } from 'next-themes';
 
 export default function ThemeToggle() {
@@ -21,14 +22,21 @@ export default function ThemeToggle() {
 
   return (
     <button
-      type="button"
-      aria-pressed={isDark}
       aria-label={isDark ? '라이트 모드로 전환' : '다크 모드로 전환'}
-      onClick={() => setTheme(isDark ? 'light' : 'dark')}
+      aria-pressed={isDark}
       className="group flex h-36 w-36 items-center justify-center rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-surface-card)] text-[color:var(--color-text-sub)] shadow-[0_10px_30px_rgba(2,6,23,0.08)] transition duration-200 hover:-translate-y-0.5 hover:text-[color:var(--color-text-main)]"
+      type="button"
+      onClick={() => setTheme(isDark ? 'light' : 'dark')}
     >
       {isDark ? (
-        <svg viewBox="0 0 24 24" className="h-18 w-18" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden="true">
+        <svg
+          aria-hidden="true"
+          className="h-18 w-18"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          viewBox="0 0 24 24"
+        >
           <path d="M12 3v2.5" strokeLinecap="round" />
           <path d="M12 18.5v2.5" strokeLinecap="round" />
           <path d="M4.9 4.9l1.8 1.8" strokeLinecap="round" />
@@ -40,7 +48,14 @@ export default function ThemeToggle() {
           <circle cx="12" cy="12" r="3.8" />
         </svg>
       ) : (
-        <svg viewBox="0 0 24 24" className="h-18 w-18" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden="true">
+        <svg
+          aria-hidden="true"
+          className="h-18 w-18"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          viewBox="0 0 24 24"
+        >
           <path d="M20 15.5A8.5 8.5 0 1 1 8.5 4a7 7 0 0 0 11.5 11.5Z" strokeLinecap="round" strokeLinejoin="round" />
         </svg>
       )}


### PR DESCRIPTION
## Problems :mag:

 - `npm run lint`가 실제 코드 문제 없이도 `import/order`에서 "typescript with invalid interface loaded as resolver" 경고를 냄
 - `react-hooks/set-state-in-effect`가 next-themes의 공식 hydration mismatch 방지 패턴(mounted state + useEffect)을 위반으로 잡음
 - VSCode에서 `.tsx` 파일을 열면 Stylelint 확장이 CssSyntaxError를 냄 (`Unknown word 'use client'`)

## Causes  :bulb:

 - `eslint-config-next`가 강제하는 `import/resolver: { typescript: {...} }` 설정에 필요한 `eslint-import-resolver-typescript` 패키지가 프로젝트 루트에 호이스팅되지 않고 `eslint-config-next/node_modules`에만 nested되어 있어, 린트 대상 파일 위치에서 리졸버를 찾지 못하고 대신 동명의 `typescript` 컴파일러 패키지를 리졸버로 잘못 로드함
 - `react-hooks/set-state-in-effect` 규칙이 overly strict한지 [facebook/react#34743](https://github.com/facebook/react/issues/34743)에서 아직 논의 중
 - `.vscode/settings.json`의 `stylelint.validate`에 `typescript`/`typescriptreact`가 포함돼 있었는데, 이 프로젝트는 CSS-in-JS 없이 순수 `.css`만 stylelint 대상으로 씀 (`package.json`의 `stylelint` 스크립트도 `src/**/*.css`만 지정)

## Changes :memo:

 - `eslint-import-resolver-typescript`를 프로젝트 루트에 직접 설치해 리졸버가 정상 호이스팅되도록 함
 - 리졸버가 고쳐지면서 드러난 실제 `import/order`, `perfectionist/sort-jsx-props` 위반을 `eslint --fix`로 정리 (`layout.tsx`, `page.tsx`, `Header.tsx`, `ThemeToggle.tsx`)
 - `react-hooks/set-state-in-effect`를 임시로 off 처리 (근거 이슈 링크 및 날짜 주석 포함)
 - `.vscode/settings.json`의 `stylelint.validate`를 `["css"]`로 축소

## Testing :test_tube:

 - [x] `npm run lint` 클린 확인 (에러/경고 0개)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 개발 환경의 스타일 검사 범위를 조정하고, 일부 린트 규칙에 대한 설명을 보강했습니다.
  * 타입스크립트 관련 개발 의존성이 추가되었습니다.
* **Style**
  * 레이아웃, 홈 화면, 헤더, 테마 전환 버튼의 마크업과 속성 정렬을 정리했습니다.
  * 코드 전반의 import 및 JSX 형식을 일관되게 맞췄습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->