### PR TITLE
chore: introduce SVG sprite system for icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@
 /.next/
 /out/
 
+# generated svg sprite
+/public/sprites.svg
+
 # production
 /build
 

--- a/docs/Architecture-Decision-Records.md
+++ b/docs/Architecture-Decision-Records.md
@@ -195,3 +195,31 @@
 - PR 머지 전에 린트·타입 오류가 반드시 통과되어야 하므로 코드 품질 게이팅이 자동화됨
 - 로컬 린트 실행을 잊어도 CI가 잡아줌
 - 워크플로우 파일의 Action 버전이 핀닝되어 예기치 않은 업스트림 변경에 영향을 받지 않음
+
+---
+
+## 🎯 2026-07-02: SVG Sprite 시스템 도입
+
+### Context
+
+- 아이콘을 컴포넌트마다 개별 import하면 번들 크기가 커지고 관리가 분산됨
+- 이 프로젝트는 `dev`는 Webpack(`next dev --webpack`), `build`는 Turbopack(Next 16 기본값)을 각각 사용해, SVGR처럼 번들러 로더에 의존하는 svg-to-component 방식은 두 번들러 설정을 각각 만들고 계속 동기화해야 하는 부담이 있음
+- 다크/라이트 테마 전환 인프라(2026-06-30 ADR)가 이미 있어 아이콘도 `currentColor` 기반으로 테마 토큰과 자연스럽게 연동될 필요가 있음
+- CodeRabbit path instructions로 Server Component 우선 설계를 지향하는데, 검토했던 대안(Portal로 심볼을 런타임에 DOM에 주입하는 방식)은 client mount가 필요해 SSR 이점이 사라지고 초기 렌더에 아이콘 깜빡임(FOIC)이 생길 수 있음
+
+### Decision
+
+- `scripts/build-svg-sprite.mts`: `src/icons/*.svg` 원본을 스캔해 `<symbol>`로 묶은 단일 `public/sprites.svg`를 생성하는 빌드타임 스크립트 도입. Node 24의 네이티브 TypeScript 실행 지원을 활용해 별도 트랜스파일 없이 `.mts`로 작성(`tsc` 타입체크 대상에도 포함)
+- `npm run icons`로 실행하며 `predev`/`prebuild`에 연결해 항상 최신 sprite를 보장
+- 생성된 `public/sprites.svg`는 `.gitignore`에 추가해 버전관리 대상에서 제외 — 단일 소스는 `src/icons/*.svg`
+- `src/components/common/Icon.tsx` 공통 컴포넌트 추가: `<svg><use href="/sprites.svg#icon-{name}" /></svg>`를 렌더링하는 서버 컴포넌트로, 번들러나 클라이언트 마운트에 의존하지 않음
+- 아이콘 소스는 `fill="none" stroke="currentColor"` 기반으로 작성해 테마 토큰 색상을 그대로 상속받도록 함
+- `ThemeToggle`의 인라인 sun/moon SVG를 `Icon` 컴포넌트로 교체해 실사용 검증
+
+### Consequences
+
+- `src/icons/`에 svg 파일만 추가하면 별도 등록 없이 sprite에 자동 반영됨
+- Turbopack/Webpack 번들러 차이에 영향받지 않는 아이콘 파이프라인 확보
+- 브라우저가 `sprites.svg`를 최초 1회만 캐싱하므로 이후 페이지 이동 시 재다운로드가 없음
+- 서버 컴포넌트로 아이콘을 렌더링할 수 있어 SSR 시점에 바로 아이콘이 보이고 클라이언트 마운트를 기다릴 필요가 없음
+- 아이콘 개수가 늘어나면 `Icon.tsx`의 `IconName` 유니언 타입을 수동으로 유지보수해야 함 — 개수가 많아지면 codegen 도입을 재검토

--- a/package.json
+++ b/package.json
@@ -3,12 +3,15 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "predev": "npm run icons",
     "dev": "next dev --webpack",
+    "prebuild": "npm run icons",
     "build": "next build",
     "start": "next start",
     "lint": "eslint && npm run stylelint",
     "stylelint": "stylelint \"src/**/*.css\"",
-    "tsc": "tsc --noEmit"
+    "tsc": "tsc --noEmit",
+    "icons": "node scripts/build-svg-sprite.mts"
   },
   "dependencies": {
     "next": "16.2.9",

--- a/scripts/build-svg-sprite.mts
+++ b/scripts/build-svg-sprite.mts
@@ -1,0 +1,34 @@
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const ICONS_DIR = path.join(process.cwd(), "src/icons");
+const OUTPUT_FILE = path.join(process.cwd(), "public/sprites.svg");
+
+const SVG_TAG_PATTERN = /<svg([^>]*)>([\s\S]*)<\/svg>/;
+const STRIPPED_ATTRS_PATTERN = /\s(xmlns|width|height)="[^"]*"/g;
+
+async function buildSprite(): Promise<void> {
+  const files = (await readdir(ICONS_DIR)).filter((file) => file.endsWith(".svg"));
+
+  const symbols = await Promise.all(files.map(async (file): Promise<string> => {
+    const name = path.basename(file, ".svg");
+    const source = await readFile(path.join(ICONS_DIR, file), "utf-8");
+
+    const match = source.match(SVG_TAG_PATTERN);
+    if (!match) {
+      throw new Error(`Invalid SVG source: ${file}`);
+    }
+
+    const [, attrs, content] = match;
+    const symbolAttrs = attrs.replace(STRIPPED_ATTRS_PATTERN, "");
+
+    return `<symbol id="icon-${name}"${symbolAttrs}>${content.trim()}</symbol>`;
+  }));
+
+  const sprite = `<svg xmlns="http://www.w3.org/2000/svg" style="display:none">\n${symbols.join("\n")}\n</svg>\n`;
+
+  await writeFile(OUTPUT_FILE, sprite);
+  console.warn(`Generated ${OUTPUT_FILE} (${files.length} icons)`);
+}
+
+await buildSprite();

--- a/scripts/build-svg-sprite.mts
+++ b/scripts/build-svg-sprite.mts
@@ -5,7 +5,7 @@ const ICONS_DIR = path.join(process.cwd(), "src/icons");
 const OUTPUT_FILE = path.join(process.cwd(), "public/sprites.svg");
 
 const SVG_TAG_PATTERN = /<svg([^>]*)>([\s\S]*)<\/svg>/;
-const STRIPPED_ATTRS_PATTERN = /\s(xmlns|width|height)="[^"]*"/g;
+const STRIPPED_ATTRS_PATTERN = /\s(xmlns|width|height|id)="[^"]*"/g;
 
 async function buildSprite(): Promise<void> {
   const files = (await readdir(ICONS_DIR)).filter((file) => file.endsWith(".svg"));

--- a/src/components/common/Icon.tsx
+++ b/src/components/common/Icon.tsx
@@ -1,0 +1,15 @@
+import { SVGAttributes } from 'react';
+
+type IconName = 'moon' | 'sun';
+
+type IconProps = {
+  name: IconName;
+} & SVGAttributes<SVGSVGElement>;
+
+export default function Icon({ name, ...props }: IconProps) {
+  return (
+    <svg aria-hidden="true" {...props}>
+      <use href={`/sprites.svg#icon-${name}`} />
+    </svg>
+  );
+}

--- a/src/components/layout/ThemeToggle.tsx
+++ b/src/components/layout/ThemeToggle.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from 'react';
 
 import { useTheme } from 'next-themes';
 
+import Icon from '@components/common/Icon';
+
 export default function ThemeToggle() {
   const [mounted, setMounted] = useState(false);
   const { resolvedTheme, setTheme } = useTheme();
@@ -28,37 +30,7 @@ export default function ThemeToggle() {
       type="button"
       onClick={() => setTheme(isDark ? 'light' : 'dark')}
     >
-      {isDark ? (
-        <svg
-          aria-hidden="true"
-          className="h-18 w-18"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.8"
-          viewBox="0 0 24 24"
-        >
-          <path d="M12 3v2.5" strokeLinecap="round" />
-          <path d="M12 18.5v2.5" strokeLinecap="round" />
-          <path d="M4.9 4.9l1.8 1.8" strokeLinecap="round" />
-          <path d="M17.3 17.3l1.8 1.8" strokeLinecap="round" />
-          <path d="M3 12h2.5" strokeLinecap="round" />
-          <path d="M18.5 12H21" strokeLinecap="round" />
-          <path d="M4.9 19.1l1.8-1.8" strokeLinecap="round" />
-          <path d="M17.3 6.7l1.8-1.8" strokeLinecap="round" />
-          <circle cx="12" cy="12" r="3.8" />
-        </svg>
-      ) : (
-        <svg
-          aria-hidden="true"
-          className="h-18 w-18"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.8"
-          viewBox="0 0 24 24"
-        >
-          <path d="M20 15.5A8.5 8.5 0 1 1 8.5 4a7 7 0 0 0 11.5 11.5Z" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
-      )}
+      <Icon className="h-18 w-18" name={isDark ? 'sun' : 'moon'} />
     </button>
   );
 }

--- a/src/icons/moon.svg
+++ b/src/icons/moon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+  <path d="M20 15.5A8.5 8.5 0 1 1 8.5 4a7 7 0 0 0 11.5 11.5Z" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/src/icons/sun.svg
+++ b/src/icons/sun.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+  <path d="M12 3v2.5" stroke-linecap="round" />
+  <path d="M12 18.5v2.5" stroke-linecap="round" />
+  <path d="M4.9 4.9l1.8 1.8" stroke-linecap="round" />
+  <path d="M17.3 17.3l1.8 1.8" stroke-linecap="round" />
+  <path d="M3 12h2.5" stroke-linecap="round" />
+  <path d="M18.5 12H21" stroke-linecap="round" />
+  <path d="M4.9 19.1l1.8-1.8" stroke-linecap="round" />
+  <path d="M17.3 6.7l1.8-1.8" stroke-linecap="round" />
+  <circle cx="12" cy="12" r="3.8" />
+</svg>


### PR DESCRIPTION
## Problems :mag:

 - 아이콘을 컴포넌트마다 개별 인라인 SVG로 작성하고 있어 재사용이 어렵고 관리가 분산됨
 - 다크/라이트 테마 전환 시 아이콘 색상을 일관되게 관리할 공통 체계가 없음

## Causes  :bulb:

 - 초기에는 `ThemeToggle` 등에서 필요할 때마다 인라인 `<svg>`를 직접 작성해왔음 (issue #23)

## Changes :memo:

 - `scripts/build-svg-sprite.mts` 추가: `src/icons/*.svg`를 스캔해 `<symbol>`로 묶은 단일 `public/sprites.svg`를 생성하는 빌드타임 스크립트 (Node 24 네이티브 TS 실행 활용)
 - `npm run icons` 스크립트 추가, `predev`/`prebuild`에 연결해 항상 최신 sprite 유지
 - `src/components/common/Icon.tsx` 공통 컴포넌트 추가 — `<svg><use href="/sprites.svg#icon-{name}" /></svg>` 렌더링, 서버 컴포넌트로 동작
 - `src/icons/sun.svg`, `moon.svg` 추가, `ThemeToggle`의 인라인 SVG를 `Icon` 컴포넌트로 교체해 실사용 검증
 - 생성 파일인 `public/sprites.svg`는 `.gitignore`에 추가 (단일 소스는 `src/icons/*.svg`)
 - ADR에 스프라이트 방식 선정 근거 기록 (Portal 방식 대신 정적 파일 + `<use href>` 채택 이유 포함)

## Testing :test_tube:

 - [x] `npm run dev`로 실행 후 `ThemeToggle`에서 `sun`/`moon` 아이콘이 정상적으로 토글되는지 브라우저에서 직접 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 아이콘을 단일 스프라이트로 관리해, 더 안정적으로 표시되도록 개선했습니다.
  * 테마 전환 버튼의 아이콘이 공통 아이콘 방식으로 바뀌어 일관된 표시를 제공합니다.

* **개선**
  * 개발 및 빌드 과정에서 아이콘 스프라이트가 자동으로 최신 상태로 생성되도록 연결했습니다.
  * 아이콘 관련 생성 파일은 저장소에 포함되지 않도록 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->