### PR TITLE
chore: extend font/shadow/z-index design tokens and replace arbitrary values

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -8,6 +8,7 @@
       }
     ],
     "import-notation": "string",
-    "property-no-vendor-prefix": null
+    "property-no-vendor-prefix": null,
+    "custom-property-pattern": null
   }
 }

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -18,26 +18,26 @@ export default async function Home({ params }: Props) {
         <div className="absolute -bottom-60 -left-40 h-350 w-500 rounded-full bg-[color:var(--color-secondary)]/15 blur-[9rem]" />
         <div className="absolute -right-40 top-0 h-280 w-340 rounded-full bg-[color:var(--color-accent)]/8 blur-[7rem]" />
       </div>
-      <div className="relative z-10 flex flex-col items-center gap-20 text-center">
-        <div className="flex items-center gap-8 rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-surface-card)]/80 px-16 py-7 shadow-[0_16px_50px_rgba(2,6,23,0.08)] backdrop-blur">
+      <div className="relative z-[var(--z-content)] flex flex-col items-center gap-20 text-center">
+        <div className="flex items-center gap-8 rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-surface-card)]/80 px-16 py-7 shadow-badge backdrop-blur">
           <span className="h-7 w-7 animate-pulse rounded-full bg-[color:var(--color-accent)]" />
-          <span className="text-[1.1rem] font-medium tracking-[0.14em] uppercase text-[color:var(--color-accent)]">
+          <span className="text-xs font-medium tracking-label uppercase text-[color:var(--color-accent)]">
             {t('badge')}
           </span>
         </div>
-        <h1 className="max-w-740 text-[4rem] font-bold leading-[1.12] tracking-[-0.02em] sm:text-[5.2rem] md:text-[6.4rem]">
+        <h1 className="max-w-740 text-4xl font-bold tracking-tight sm:text-5xl md:text-6xl">
           <span className="text-[color:var(--color-text-main)]">{t('titleLine1')}</span>
           <br />
           <span className="gradient-text">{t('titleLine2')}</span>
         </h1>
-        <p className="max-w-560 text-[1.6rem] leading-[1.8] text-[color:var(--color-text-sub)]">
+        <p className="max-w-560 text-lg text-[color:var(--color-text-sub)]">
           {t('subtitle')}
         </p>
         <div className="mt-5 flex flex-col gap-8 sm:flex-row">
-          <Link className="rounded-full bg-[color:var(--color-accent)] px-30 py-13 text-[1.4rem] font-semibold text-white shadow-[0_18px_45px_rgba(6,182,212,0.25)] transition-all duration-200 hover:-translate-y-0.5 hover:bg-[color:var(--color-accent-hover)]" href="#projects">
+          <Link className="rounded-full bg-[color:var(--color-accent)] px-30 py-13 text-base font-semibold text-white shadow-glow-accent transition-all duration-200 hover:-translate-y-0.5 hover:bg-[color:var(--color-accent-hover)]" href="#projects">
             {t('ctaPrimary')}
           </Link>
-          <Link className="rounded-full border border-[color:var(--color-border)] px-30 py-13 text-[1.4rem] font-medium text-[color:var(--color-text-sub)] transition-all duration-200 hover:border-[color:var(--color-accent)]/30 hover:bg-[color:var(--color-surface-card)] hover:text-[color:var(--color-text-main)]" href="#approach">
+          <Link className="rounded-full border border-[color:var(--color-border)] px-30 py-13 text-base font-medium text-[color:var(--color-text-sub)] transition-all duration-200 hover:border-[color:var(--color-accent)]/30 hover:bg-[color:var(--color-surface-card)] hover:text-[color:var(--color-text-main)]" href="#approach">
             {t('ctaSecondary')}
           </Link>
         </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -11,9 +11,9 @@ export default async function Header() {
   ];
 
   return (
-    <header className="sticky top-0 z-50 w-full border-b border-[color:var(--color-border)] bg-[color:var(--color-surface-elevated)]/80 backdrop-blur-sm">
+    <header className="sticky top-0 z-[var(--z-header)] w-full border-b border-[color:var(--color-border)] bg-[color:var(--color-surface-elevated)]/80 backdrop-blur-sm">
       <div className="mx-auto flex h-40 max-w-800 items-center justify-between px-15">
-        <Link className="text-[1.8rem] font-semibold tracking-tight text-[color:var(--color-text-main)]" href="/">
+        <Link className="text-xl font-semibold tracking-tight text-[color:var(--color-text-main)]" href="/">
           Polio
         </Link>
         <div className="flex items-center gap-12">
@@ -22,7 +22,7 @@ export default async function Header() {
               {NAV_LINKS.map(({ label, href }) => (
                 <li key={href}>
                   <Link
-                    className="text-[1.4rem] text-[color:var(--color-text-sub)] transition-colors hover:text-[color:var(--color-text-main)]"
+                    className="text-base text-[color:var(--color-text-sub)] transition-colors hover:text-[color:var(--color-text-main)]"
                     href={href}
                   >
                     {label}

--- a/src/components/layout/LocaleSwitcher.tsx
+++ b/src/components/layout/LocaleSwitcher.tsx
@@ -11,7 +11,7 @@ export default function LocaleSwitcher() {
   return (
     <button
       aria-label={nextLocale === 'en' ? t('switchToEn') : t('switchToKo')}
-      className="flex h-36 items-center justify-center rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-surface-card)] px-14 text-[1.3rem] font-semibold text-[color:var(--color-text-sub)] shadow-[0_10px_30px_rgba(2,6,23,0.08)] transition duration-200 hover:-translate-y-0.5 hover:text-[color:var(--color-text-main)]"
+      className="flex h-36 items-center justify-center rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-surface-card)] px-14 text-sm font-semibold text-[color:var(--color-text-sub)] shadow-control transition duration-200 hover:-translate-y-0.5 hover:text-[color:var(--color-text-main)]"
       type="button"
       onClick={switchLocale}
     >

--- a/src/components/layout/ThemeToggle.tsx
+++ b/src/components/layout/ThemeToggle.tsx
@@ -26,7 +26,7 @@ export default function ThemeToggle() {
     <button
       aria-label={isDark ? '라이트 모드로 전환' : '다크 모드로 전환'}
       aria-pressed={isDark}
-      className="group flex h-36 w-36 items-center justify-center rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-surface-card)] text-[color:var(--color-text-sub)] shadow-[0_10px_30px_rgba(2,6,23,0.08)] transition duration-200 hover:-translate-y-0.5 hover:text-[color:var(--color-text-main)]"
+      className="group flex h-36 w-36 items-center justify-center rounded-full border border-[color:var(--color-border)] bg-[color:var(--color-surface-card)] text-[color:var(--color-text-sub)] shadow-control transition duration-200 hover:-translate-y-0.5 hover:text-[color:var(--color-text-main)]"
       type="button"
       onClick={() => setTheme(isDark ? 'light' : 'dark')}
     >

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -4,6 +4,37 @@
 @theme {
   --spacing: 0.1rem;
   --font-sans: var(--font-inter), "Pretendard Variable", "Noto Sans KR", sans-serif;
+
+  /* Font size scale — paired --text-*--line-height applies automatically with each text-* utility */
+  --text-xs: 1.1rem;
+  --text-xs--line-height: 1.4;
+  --text-sm: 1.3rem;
+  --text-sm--line-height: 1.4;
+  --text-base: 1.4rem;
+  --text-base--line-height: 1.6;
+  --text-lg: 1.6rem;
+  --text-lg--line-height: 1.8;
+  --text-xl: 1.8rem;
+  --text-xl--line-height: 1.3;
+  --text-2xl: 2.2rem;
+  --text-2xl--line-height: 1.3;
+  --text-3xl: 2.8rem;
+  --text-3xl--line-height: 1.25;
+  --text-4xl: 4rem;
+  --text-4xl--line-height: 1.12;
+  --text-5xl: 5.2rem;
+  --text-5xl--line-height: 1.12;
+  --text-6xl: 6.4rem;
+  --text-6xl--line-height: 1.12;
+
+  /* font-weight/tracking/leading use Tailwind's built-in scale except this project-specific label style */
+  --tracking-label: 0.14em;
+
+  /* radius/breakpoint: Tailwind 기본 스케일 그대로 사용, 별도 커스텀 불필요 (필요 시 추가) */
+
+  --shadow-control: 0 10px 30px rgb(2 6 23 / 8%);
+  --shadow-badge: 0 16px 50px rgb(2 6 23 / 8%);
+  --shadow-glow-accent: 0 18px 45px rgb(6 182 212 / 25%);
 }
 
 :root {
@@ -22,6 +53,13 @@
   --color-text-main: #f8fafc;
   --color-text-sub: #9aa8c3;
   --color-border: rgb(148 163 184 / 18%);
+
+  /* z-index: Tailwind에 스케일 네임스페이스가 없어 커스텀 프로퍼티 + 임의값(z-[var(--z-*)])으로 사용 */
+  --z-content: 10;
+  --z-header: 50;
+  --z-dropdown: 60;
+  --z-modal: 70;
+  --z-toast: 80;
 }
 
 :root.light {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -32,9 +32,9 @@
 
   /* radius/breakpoint: Tailwind 기본 스케일 그대로 사용, 별도 커스텀 불필요 (필요 시 추가) */
 
-  --shadow-control: 0 10px 30px rgb(2 6 23 / 8%);
-  --shadow-badge: 0 16px 50px rgb(2 6 23 / 8%);
-  --shadow-glow-accent: 0 18px 45px rgb(6 182 212 / 25%);
+  --shadow-control: 0 1rem 3rem rgb(2 6 23 / 8%);
+  --shadow-badge: 0 1.6rem 5rem rgb(2 6 23 / 8%);
+  --shadow-glow-accent: 0 1.8rem 4.5rem rgb(6 182 212 / 25%);
 }
 
 :root {


### PR DESCRIPTION
Related to #22

## Problems :mag:

 - `@theme`에 폰트 크기, 섀도우, z-index 토큰이 없어 컴포넌트마다 `text-[1.4rem]`, `shadow-[0_10px_30px_rgba(...)]`, `z-10`/`z-50` 같은 임의값이 산재
 - 임의값 방식은 재사용이 안 되고, 값이 바뀌면 컴포넌트를 일일이 찾아 수정해야 함

## Causes  :bulb:

 - 이슈 #22 진행 중 색상/spacing 토큰만 먼저 정의되고 font/shadow/z-index 토큰화는 후순위로 남아있었음
 - Tailwind v4는 z-index 전용 theme 네임스페이스가 없어 기본 방식으로는 토큰화가 안 됨

## Changes :memo:

 - `globals.css` `@theme`에 `--text-*` 폰트 크기 스케일(라인하이트 페어링 포함), `--tracking-label`, `--shadow-control`/`--shadow-badge`/`--shadow-glow-accent` 토큰 추가
 - z-index는 `:root`에 커스텀 프로퍼티(`--z-content`/`--z-header`/`--z-dropdown`/`--z-modal`/`--z-toast`)로 정의하고 `z-[var(--z-*)]`로 사용
 - `page.tsx`, `Header`, `LocaleSwitcher`, `ThemeToggle`의 `text-[]`/`shadow-[]`/`z-10`·`z-50` 임의값을 토큰 클래스로 교체
 - Tailwind v4 line-height 페어링 네이밍(`--text-*--line-height`)이 기존 stylelint kebab-case 규칙과 충돌해 `custom-property-pattern` 룰 비활성화

## Testing :test_tube:

 - [x] `npm run lint` / `npm run stylelint` 통과 확인
 - [x] `npm run build` 정상 빌드 확인
 - [x] 다크/라이트 모드에서 헤더/히어로 영역 시각 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 헤더, 히어로 영역, 언어 전환, 테마 전환 버튼의 시각 스타일이 정리되어 더 일관된 크기와 그림자로 표시됩니다.
  * 주요 제목, 본문, 버튼 텍스트의 타이포그래피가 조정되어 전체 화면의 가독성이 개선됩니다.
* **Refactor**
  * 화면 요소들의 레이어와 스타일 기준이 통합되어, 오버레이와 상호작용 요소의 표시가 더 안정적으로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->