### PR TITLE
feat: add About page with timeline, highlights, and tech stack

### DIFF
--- a/docs/PORTFOLIO-SPEC.md
+++ b/docs/PORTFOLIO-SPEC.md
@@ -72,6 +72,44 @@ Complex problems, Structured systems.
   - MOS Web Portal 프로젝트 CLI 없이 0부터 세팅
 - 기술 스택 섹션 (카테고리별 정리)
 
+**Tech Stack 상세**
+
+### 🌐 Frontend (Core & Libraries)
+* React (React 19 Beta 선행 도입 및 아키텍처 검토 경험)
+* TypeScript (명시적 타입 선언을 통한 엄격한 타입 안정성 확보)
+* Next.js (개인 프로젝트 및 아키텍처 검토)
+* Vanilla Extract (정적 스타일링 및 제로 런타임 CSS 기술 스택)
+* Emotion / styled-components (CSS-in-JS 스타일링 아키텍처 고도화)
+* Tailwind CSS (빌드 산출물 비교 및 전환 경험)
+* MUI (Material UI - 상용 패키지 대규모 마이그레이션 및 커스텀 컴포넌트 대체 경험)
+* HTML5 / CSS3 / Web 표준 (window.print, Print CSS 인프라 구축)
+* 3D Canvas / WebGL (사내 3D 렌더링 모듈 연동 및 런타임 성능 최적화 경험)
+
+### 📦 State Management & Data Fetching
+* React Query (TanStack Query - 서버 상태 동기화 및 캐싱 전략 수립)
+* Zustand (경량화된 전사 전역 상태 관리 체계 설계)
+* React Hooks (무한 스크롤, 상태 제어 등 전사 공통 커스텀 훅 패키지 단독 개발)
+
+### 🛠️ Tooling & API Automation
+* Orval (OpenAPI 스펙 기반 API 코드 자동 생성 스크립트 구축 및 DX 개선)
+* Vite (빌드 및 개발 환경 생산성 개선)
+* modern-screenshot / html-to-image (웹 화면 캡처 및 PDF 렌더링 엔진 기술 검토)
+* Nx (Micro Frontend Architecture - MFA 도입을 위한 모노레포 빌드 시스템 검토)
+
+### 🧪 Testing & Quality Control
+* Vitest (jsdom 기반 컴포넌트 단위 테스트 환경 구축)
+* Playwright (E2E 테스트 자동화 및 시나리오 구축)
+* ESLint / Stylistic (코드 정적 분석 및 포맷팅 컨벤션 표준화)
+
+### 🚀 Infra & DevOps (CI/CD)
+* GitHub Actions (정적 분석, PR 워크플로우 자동화)
+* Semantic Release (커밋 기반 자동 버전 관리 및 NPM/GitHub Package Registry 배포 자동화)
+* Git / GitHub (브랜치 전략 운영 및 기민한 코드 리뷰 문화 주도)
+
+### 📊 Collaboration & Domain
+* Jira / Slack / Figma (디자인 시안 분석 및 컴포넌트 단위 매핑 협업)
+* 대규모 데이터 중심의 논리적 사고 및 공정/운영 프로세스 이해도 (이전 엔지니어링 경력 기반)
+
 ---
 
 ### 3. `/projects` — Projects

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -1,0 +1,133 @@
+import type { Metadata } from 'next';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+
+type Props = {
+  params: Promise<{ locale: string }>;
+};
+
+type TimelineItem = {
+  period: string;
+  title: string;
+  description: string;
+};
+
+type HighlightItem = {
+  title: string;
+  description: string;
+};
+
+type TechStackItem = {
+  name: string;
+  description: string;
+};
+
+type TechStackCategory = {
+  title: string;
+  items: TechStackItem[];
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'About' });
+
+  return {
+    title: t('metaTitle'),
+    description: t('metaDescription'),
+  };
+}
+
+export default async function AboutPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  const t = await getTranslations('About');
+  const timelineItems = t.raw('timeline.items') as TimelineItem[];
+  const highlightItems = t.raw('highlights.items') as HighlightItem[];
+  const techStackCategories = t.raw('techStack.categories') as TechStackCategory[];
+
+  return (
+    <main className="mx-auto flex w-full max-w-800 flex-col gap-64 px-15 py-80">
+      <header className="flex flex-col gap-12">
+        <span className="text-xs font-medium tracking-label uppercase text-[color:var(--color-accent)]">
+          {t('eyebrow')}
+        </span>
+        <h1 className="text-3xl font-bold text-[color:var(--color-text-main)] sm:text-4xl">
+          {t('heading')}
+        </h1>
+        <p className="max-w-640 text-lg text-[color:var(--color-text-sub)]">
+          {t('intro')}
+        </p>
+      </header>
+      <section className="flex flex-col gap-24">
+        <h2 className="text-xl font-semibold text-[color:var(--color-text-main)]">
+          {t('timeline.title')}
+        </h2>
+        <ol className="flex flex-col">
+          {timelineItems.map((item, index) => (
+            <li key={item.title} className="grid grid-cols-[auto_1fr] gap-16">
+              <div className="flex flex-col items-center">
+                <span className="mt-4 h-10 w-10 shrink-0 rounded-full bg-[color:var(--color-accent)] shadow-glow-accent" />
+                {index < timelineItems.length - 1 && (
+                  <span className="w-1 flex-1 bg-[color:var(--color-border)]" />
+                )}
+              </div>
+              <div className="pb-32">
+                <span className="text-xs font-medium tracking-label uppercase text-[color:var(--color-text-sub)]">
+                  {item.period}
+                </span>
+                <h3 className="mt-4 text-lg font-semibold text-[color:var(--color-text-main)]">
+                  {item.title}
+                </h3>
+                <p className="mt-4 text-base text-[color:var(--color-text-sub)]">
+                  {item.description}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      </section>
+      <section className="flex flex-col gap-24">
+        <h2 className="text-xl font-semibold text-[color:var(--color-text-main)]">
+          {t('highlights.title')}
+        </h2>
+        <div className="grid gap-16 sm:grid-cols-3">
+          {highlightItems.map((item) => (
+            <div
+              key={item.title}
+              className="rounded-xl border border-[color:var(--color-border)] bg-[color:var(--color-surface-card)] p-20 shadow-control"
+            >
+              <h3 className="text-base font-semibold text-[color:var(--color-text-main)]">
+                {item.title}
+              </h3>
+              <p className="mt-8 text-sm text-[color:var(--color-text-sub)]">
+                {item.description}
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+      <section className="flex flex-col gap-24">
+        <h2 className="text-xl font-semibold text-[color:var(--color-text-main)]">
+          {t('techStack.title')}
+        </h2>
+        <div className="grid gap-24 sm:grid-cols-2">
+          {techStackCategories.map((category) => (
+            <div key={category.title}>
+              <h3 className="text-sm font-semibold uppercase tracking-label text-[color:var(--color-text-sub)]">
+                {category.title}
+              </h3>
+              <ul className="mt-12 flex flex-col gap-8">
+                {category.items.map((item) => (
+                  <li key={item.name} className="text-sm text-[color:var(--color-text-sub)]">
+                    <span className="font-semibold text-[color:var(--color-text-main)]">{item.name}</span>
+                    {' — '}
+                    {item.description}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,5 +1,6 @@
-import Link from 'next/link';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
+
+import { Link } from '@/i18n/navigation';
 
 type Props = {
   params: Promise<{ locale: string }>;
@@ -37,7 +38,7 @@ export default async function Home({ params }: Props) {
           <Link className="rounded-full bg-[color:var(--color-accent)] px-30 py-13 text-base font-semibold text-white shadow-glow-accent transition-all duration-200 hover:-translate-y-0.5 hover:bg-[color:var(--color-accent-hover)]" href="#projects">
             {t('ctaPrimary')}
           </Link>
-          <Link className="rounded-full border border-[color:var(--color-border)] px-30 py-13 text-base font-medium text-[color:var(--color-text-sub)] transition-all duration-200 hover:border-[color:var(--color-accent)]/30 hover:bg-[color:var(--color-surface-card)] hover:text-[color:var(--color-text-main)]" href="#approach">
+          <Link className="rounded-full border border-[color:var(--color-border)] px-30 py-13 text-base font-medium text-[color:var(--color-text-sub)] transition-all duration-200 hover:border-[color:var(--color-accent)]/30 hover:bg-[color:var(--color-surface-card)] hover:text-[color:var(--color-text-main)]" href="/about">
             {t('ctaSecondary')}
           </Link>
         </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -8,6 +8,7 @@ export default async function Header() {
   const t = await getTranslations("Header");
   const NAV_LINKS = [
     { label: t("home"), href: "/" },
+    { label: t("about"), href: "/about" },
   ];
 
   return (

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -4,7 +4,8 @@
     "description": "Portfolio of Sukhyeon, a frontend engineer who solves hard problems with structure and builds systems that didn't exist before."
   },
   "Header": {
-    "home": "Home"
+    "home": "Home",
+    "about": "About"
   },
   "Hero": {
     "badge": "Frontend Architect",
@@ -17,5 +18,108 @@
   "LocaleSwitcher": {
     "switchToEn": "Switch to English",
     "switchToKo": "한국어로 전환"
+  },
+  "About": {
+    "metaTitle": "About",
+    "metaDescription": "Sukhyeon's career timeline and attitude toward software.",
+    "eyebrow": "About",
+    "heading": "The attitude I bring to software",
+    "intro": "Moving from a factory engineer to a frontend engineer taught me an attitude: turn hard problems into structure, and build systems that didn't exist before.",
+    "timeline": {
+      "title": "Timeline",
+      "items": [
+        {
+          "period": "~2021",
+          "title": "Factory Engineer, LG Display",
+          "description": "Worked close to real problems on the manufacturing floor"
+        },
+        {
+          "period": "2023~",
+          "title": "Full-stack Development Immersion",
+          "description": "A technical turning point through self-study and a bootcamp"
+        },
+        {
+          "period": "2025~",
+          "title": "Medit — Frontend Engineer",
+          "description": "Building systems and leading core features"
+        }
+      ]
+    },
+    "highlights": {
+      "title": "Things I started on my own",
+      "items": [
+        {
+          "title": "Built a shared GitHub Actions repo",
+          "description": "Designed and built the shared workflows now adopted across every team repo"
+        },
+        {
+          "title": "First release of the react-components package",
+          "description": "An internal shared component package I contributed over 50% of the components to"
+        },
+        {
+          "title": "Set up MOS Web Portal from scratch",
+          "description": "Designed and built the project structure from zero, without a CLI"
+        }
+      ]
+    },
+    "techStack": {
+      "title": "Tech Stack",
+      "categories": [
+        {
+          "title": "Frontend",
+          "items": [
+            { "name": "React", "description": "Early adoption of React 19 Beta and architecture review" },
+            { "name": "TypeScript", "description": "Strict type safety through explicit type declarations" },
+            { "name": "Next.js", "description": "Personal projects and architecture evaluation" },
+            { "name": "Vanilla Extract", "description": "Static styling and zero-runtime CSS stack" },
+            { "name": "Emotion / styled-components", "description": "Advanced CSS-in-JS styling architecture" },
+            { "name": "Tailwind CSS", "description": "Build output comparison and migration experience" },
+            { "name": "MUI", "description": "Large-scale migration off a commercial package and custom component replacement" },
+            { "name": "HTML5 / CSS3 / Web Standards", "description": "Built window.print and Print CSS infrastructure" },
+            { "name": "3D Canvas / WebGL", "description": "Integrated an in-house 3D rendering module and optimized runtime performance" }
+          ]
+        },
+        {
+          "title": "State Management & Data Fetching",
+          "items": [
+            { "name": "React Query", "description": "Server state synchronization and caching strategy" },
+            { "name": "Zustand", "description": "Designed a lightweight, org-wide global state system" },
+            { "name": "React Hooks", "description": "Solo-built a company-wide custom hooks package (infinite scroll, state control, etc.)" }
+          ]
+        },
+        {
+          "title": "Tooling & API Automation",
+          "items": [
+            { "name": "Orval", "description": "Built OpenAPI-spec-based API code generation, improving DX" },
+            { "name": "Vite", "description": "Improved build and dev environment productivity" },
+            { "name": "modern-screenshot / html-to-image", "description": "Evaluated web screen capture and PDF rendering engines" },
+            { "name": "Nx", "description": "Evaluated a monorepo build system for Micro Frontend Architecture (MFA)" }
+          ]
+        },
+        {
+          "title": "Testing & Quality Control",
+          "items": [
+            { "name": "Vitest", "description": "Built a jsdom-based component unit test environment" },
+            { "name": "Playwright", "description": "E2E test automation and scenario design" },
+            { "name": "ESLint / Stylistic", "description": "Standardized static analysis and formatting conventions" }
+          ]
+        },
+        {
+          "title": "Infra & DevOps (CI/CD)",
+          "items": [
+            { "name": "GitHub Actions", "description": "Automated static analysis and PR workflows" },
+            { "name": "Semantic Release", "description": "Commit-based automatic versioning and NPM/GitHub Package Registry publishing" },
+            { "name": "Git / GitHub", "description": "Led branch strategy and an agile code review culture" }
+          ]
+        },
+        {
+          "title": "Collaboration & Domain",
+          "items": [
+            { "name": "Jira / Slack / Figma", "description": "Collaborated on design-spec analysis and component-level mapping" },
+            { "name": "Domain Insight", "description": "Data-driven logical thinking and process/operations understanding from a prior engineering career" }
+          ]
+        }
+      ]
+    }
   }
 }

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -4,7 +4,8 @@
     "description": "복잡한 문제를 구조로 풀고, 없던 체계를 만드는 프론트엔드 엔지니어 숙현의 포트폴리오입니다."
   },
   "Header": {
-    "home": "홈"
+    "home": "홈",
+    "about": "소개"
   },
   "Hero": {
     "badge": "Frontend Architect",
@@ -17,5 +18,108 @@
   "LocaleSwitcher": {
     "switchToEn": "Switch to English",
     "switchToKo": "한국어로 전환"
+  },
+  "About": {
+    "metaTitle": "소개",
+    "metaDescription": "숙현의 커리어 타임라인과 소프트웨어를 대하는 태도.",
+    "eyebrow": "About",
+    "heading": "어떤 태도로 소프트웨어를 대하는가",
+    "intro": "제조 현장의 엔지니어에서 프론트엔드 엔지니어로 전환하며 배운 건, 없던 체계를 만들고 복잡한 문제를 구조로 풀어내는 태도였습니다.",
+    "timeline": {
+      "title": "Timeline",
+      "items": [
+        {
+          "period": "~2021",
+          "title": "LG Display 공장 엔지니어",
+          "description": "제조 현장에서 문제를 가까이 마주하며 일함"
+        },
+        {
+          "period": "2023~",
+          "title": "Full-stack Development Immersion",
+          "description": "독학과 부트캠프를 통한 기술적 전환기"
+        },
+        {
+          "period": "2025~",
+          "title": "Medit — 웹 프론트엔드 엔지니어",
+          "description": "시스템 구축과 메인 피처 리드"
+        }
+      ]
+    },
+    "highlights": {
+      "title": "혼자 시작한 것들",
+      "items": [
+        {
+          "title": "GitHub Actions 공용 레포 구축",
+          "description": "팀 전체 레포에 적용된 공용 워크플로를 처음부터 설계하고 구축함"
+        },
+        {
+          "title": "react-components 패키지 최초 배포",
+          "description": "컴포넌트의 50% 이상을 기여한 사내 공용 컴포넌트 패키지"
+        },
+        {
+          "title": "MOS Web Portal 0부터 세팅",
+          "description": "CLI 없이 프로젝트 구조를 처음부터 설계하고 구축함"
+        }
+      ]
+    },
+    "techStack": {
+      "title": "Tech Stack",
+      "categories": [
+        {
+          "title": "Frontend",
+          "items": [
+            { "name": "React", "description": "React 19 Beta 선행 도입 및 아키텍처 검토 경험" },
+            { "name": "TypeScript", "description": "명시적 타입 선언을 통한 엄격한 타입 안정성 확보" },
+            { "name": "Next.js", "description": "개인 프로젝트 및 아키텍처 검토" },
+            { "name": "Vanilla Extract", "description": "정적 스타일링 및 제로 런타임 CSS 기술 스택" },
+            { "name": "Emotion / styled-components", "description": "CSS-in-JS 스타일링 아키텍처 고도화" },
+            { "name": "Tailwind CSS", "description": "빌드 산출물 비교 및 전환 경험" },
+            { "name": "MUI", "description": "상용 패키지 대규모 마이그레이션 및 커스텀 컴포넌트 대체 경험" },
+            { "name": "HTML5 / CSS3 / Web 표준", "description": "window.print, Print CSS 인프라 구축" },
+            { "name": "3D Canvas / WebGL", "description": "사내 3D 렌더링 모듈 연동 및 런타임 성능 최적화 경험" }
+          ]
+        },
+        {
+          "title": "State Management & Data Fetching",
+          "items": [
+            { "name": "React Query", "description": "서버 상태 동기화 및 캐싱 전략 수립" },
+            { "name": "Zustand", "description": "경량화된 전사 전역 상태 관리 체계 설계" },
+            { "name": "React Hooks", "description": "무한 스크롤, 상태 제어 등 전사 공통 커스텀 훅 패키지 단독 개발" }
+          ]
+        },
+        {
+          "title": "Tooling & API Automation",
+          "items": [
+            { "name": "Orval", "description": "OpenAPI 스펙 기반 API 코드 자동 생성 스크립트 구축 및 DX 개선" },
+            { "name": "Vite", "description": "빌드 및 개발 환경 생산성 개선" },
+            { "name": "modern-screenshot / html-to-image", "description": "웹 화면 캡처 및 PDF 렌더링 엔진 기술 검토" },
+            { "name": "Nx", "description": "Micro Frontend Architecture(MFA) 도입을 위한 모노레포 빌드 시스템 검토" }
+          ]
+        },
+        {
+          "title": "Testing & Quality Control",
+          "items": [
+            { "name": "Vitest", "description": "jsdom 기반 컴포넌트 단위 테스트 환경 구축" },
+            { "name": "Playwright", "description": "E2E 테스트 자동화 및 시나리오 구축" },
+            { "name": "ESLint / Stylistic", "description": "코드 정적 분석 및 포맷팅 컨벤션 표준화" }
+          ]
+        },
+        {
+          "title": "Infra & DevOps (CI/CD)",
+          "items": [
+            { "name": "GitHub Actions", "description": "정적 분석, PR 워크플로우 자동화" },
+            { "name": "Semantic Release", "description": "커밋 기반 자동 버전 관리 및 NPM/GitHub Package Registry 배포 자동화" },
+            { "name": "Git / GitHub", "description": "브랜치 전략 운영 및 기민한 코드 리뷰 문화 주도" }
+          ]
+        },
+        {
+          "title": "Collaboration & Domain",
+          "items": [
+            { "name": "Jira / Slack / Figma", "description": "디자인 시안 분석 및 컴포넌트 단위 매핑 협업" },
+            { "name": "도메인 이해도", "description": "대규모 데이터 중심의 논리적 사고 및 공정/운영 프로세스 이해도 (이전 엔지니어링 경력 기반)" }
+          ]
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Problems :mag:

 - About 페이지가 없어 Hero의 "접근 방식 살펴보기" CTA가 존재하지 않는 인페이지 앵커(#approach)를 가리키고 있었음
 - PORTFOLIO-SPEC.md에 Tech Stack 상세 목록이 비어 있어 #28의 미결정 사항으로 남아있었음

## Causes  :bulb:

 - About(#31) 페이지 자체가 아직 구현되지 않은 상태였음

## Changes :memo:

 - About(`/about`) 페이지 신규 구현: 타임라인, "혼자 시작한 것들" 강조 블록, 카테고리별 Tech Stack 섹션
 - 헤더 네비에 About 링크 추가
 - Hero의 "접근 방식 살펴보기" CTA를 `/about`으로 연결 (깨진 앵커 링크 제거)
 - PORTFOLIO-SPEC.md에 Tech Stack 상세 목록 반영

Closes #28

## Testing :test_tube:

 - [x] `npm run tsc`, `npm run lint` 통과
 - [x] 브라우저에서 About 페이지 및 Hero CTA 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * About 페이지가 새로 추가되어 타임라인, 하이라이트, 기술 스택 정보를 확인할 수 있습니다.
  * 상단 메뉴에 About 항목이 추가되었습니다.
  * 메인 화면의 주요 버튼이 About 페이지로 연결되도록 변경되었습니다.

* **개선**
  * 한국어/영어에서 About 페이지와 탐색 메뉴 문구가 모두 제공되어 다국어 지원이 확장되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->