### PR TITLE
feat: add loading/error/not-found boundaries for [locale] segment

### DIFF
--- a/docs/Architecture-Decision-Records.md
+++ b/docs/Architecture-Decision-Records.md
@@ -303,3 +303,25 @@
 - 프로젝트가 늘어나도 `src/content/projects/`에 파일만 추가하면 되고, `PROJECTS` 소비 쪽(`getStaticParams`, 목록/상세 페이지) 코드는 변경 불필요
 - 언어별 URL이 별도로 없는 기존 `localePrefix: 'never'` 정책과 동일하게, `/projects/[slug]`도 로케일 프리픽스 없이 동작
 - "기타 프로젝트"(핵심 3개 외)를 상세 페이지 없이 카드만 보여줄지 등 세부 정책은 아직 미정 — 실제로 그런 콘텐츠가 생기기 전까지는 추측성 설계를 피하고 이슈로 남겨둠
+
+## 🎯 2026-07-10: 라우트 loading/error/not-found 바운더리 추가
+
+### Context
+
+- 페이지가 3개(`/`, `/about`, `/projects`, `/projects/[slug]`까지 포함하면 4종)로 늘었는데 `loading.tsx`/`error.tsx`/`not-found.tsx`가 하나도 없어서, 잘못된 URL이나 런타임 에러 시 Next.js 기본(스타일 없는) 화면이 그대로 노출되는 상태였음(#27)
+- 이 프로젝트의 루트 레이아웃은 `src/app/[locale]/layout.tsx`(최상위에 별도 `src/app/layout.tsx` 없음) — Next.js 문서(`node_modules/next/dist/docs`)에 따르면 "루트 레이아웃이 최상위 동적 세그먼트(`[locale]` 등)로 정의된 경우, 전역 404 페이지를 layout+not-found 조합만으로 구성하기 어려운 두 케이스 중 하나"로 명시된 상황과 정확히 일치함(→ `global-not-found.js`가 이런 경우를 위해 존재, 단 아직 experimental)
+- `error.js`가 `v16.2.0`부터 새로 `unstable_retry` prop을 받는 것을 문서에서 확인 — 기존에 알려진 `reset()` 대신 이걸 우선 사용하도록 문서가 권장함(AGENTS.md가 경고하는, 훈련 데이터와 다른 breaking change 중 하나)
+
+### Decision
+
+- `src/app/[locale]/not-found.tsx`: `notFound()` 호출(잘못된 `slug`, 잘못된 `locale`)과 `[locale]` 세그먼트 내 미매칭 경로를 처리. 사이트 톤에 맞는 스타일 + 홈으로 돌아가기 링크
+- `src/app/[locale]/error.tsx`: Client Component 에러 바운더리. `reset()` 대신 `unstable_retry()` 사용(v16.2.0 신규 API, 문서가 우선 권장)
+- `src/app/[locale]/loading.tsx`: 번역 없이 순수 시각 요소(펄스 도트 3개)만 사용 — 로딩 상태는 언어 무관하게 통하는 UI라 굳이 `messages/*.json`에 키 추가 안 함
+- **루트(`src/app/not-found.tsx`, `global-not-found.js`)는 이번엔 추가하지 않음**: 이 프로젝트는 next-intl 미들웨어가 모든 경로를 내부적으로 `[locale]`이 붙은 경로로 rewrite하므로, "`[locale]` 세그먼트에 전혀 도달하지 못하는" 진짜 최상위 404는 사실상 발생하지 않음. `global-not-found`는 아직 experimental이라 지금 도입은 과함 — 실제로 이 경로가 문제되는 사례가 생기면 그때 재검토
+
+### Consequences
+
+- 잘못된 프로젝트 slug나 존재하지 않는 경로 접근 시 사이트 톤에 맞는 404 화면이 뜸 (`getProject(slug)`가 `undefined`를 반환하면 `notFound()` 호출 → 이 파일로 연결)
+- 런타임 에러 발생 시에도 빈 화면이나 Next 기본 에러 페이지 대신 재시도 가능한 UI 제공
+- `error.tsx`가 Client Component라 `generateMetadata`를 못 쓰는 제약은 그대로 — 문서에서도 이 경우 React `<title>`을 직접 쓰라고 안내하지만, 지금은 에러 페이지에 별도 메타데이터가 굳이 필요하지 않아 보류
+- 향후 최상위 404 케이스가 실제로 문제된다면 `experimental.globalNotFound` 활성화 여부를 다시 검토

--- a/src/app/[locale]/error.module.css
+++ b/src/app/[locale]/error.module.css
@@ -1,0 +1,45 @@
+.main {
+  margin: 0 auto;
+  display: flex;
+  min-height: 60vh;
+  width: 100%;
+  max-width: 80rem;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.2rem;
+  padding: 8rem 1.5rem;
+  text-align: center;
+}
+
+.title {
+  font-size: var(--text-3xl);
+  line-height: var(--line-height-3xl);
+  font-weight: 700;
+  color: var(--color-text-main);
+}
+
+.description {
+  max-width: 48rem;
+  font-size: var(--text-lg);
+  line-height: var(--line-height-lg);
+  color: var(--color-text-sub);
+}
+
+.retryButton {
+  margin-top: 1.2rem;
+  border-radius: var(--radius-full);
+  border: 1px solid var(--color-border);
+  padding: 1.3rem 3rem;
+  font-size: var(--text-base);
+  line-height: var(--line-height-base);
+  font-weight: 500;
+  color: var(--color-text-sub);
+  transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+}
+
+.retryButton:hover {
+  border-color: color-mix(in srgb, var(--color-accent) 30%, transparent);
+  background-color: var(--color-surface-card);
+  color: var(--color-text-main);
+}

--- a/src/app/[locale]/error.tsx
+++ b/src/app/[locale]/error.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { useTranslations } from 'next-intl';
+
+import styles from './error.module.css';
+
+type Props = {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+};
+
+export default function ErrorBoundary({ error, unstable_retry }: Props) {
+  const t = useTranslations('ErrorBoundary');
+
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <main className={styles.main}>
+      <h1 className={styles.title}>
+        {t('title')}
+      </h1>
+      <p className={styles.description}>
+        {t('description')}
+      </p>
+      <button className={styles.retryButton} type="button" onClick={() => unstable_retry()}>
+        {t('retry')}
+      </button>
+    </main>
+  );
+}

--- a/src/app/[locale]/loading.module.css
+++ b/src/app/[locale]/loading.module.css
@@ -1,0 +1,40 @@
+@keyframes pulse {
+  0%, 100% {
+    opacity: 0.3;
+    transform: scale(0.85);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.main {
+  display: flex;
+  min-height: 60vh;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+}
+
+.dots {
+  display: flex;
+  gap: 0.8rem;
+}
+
+.dot {
+  height: 1rem;
+  width: 1rem;
+  border-radius: var(--radius-full);
+  background: var(--color-accent);
+  animation: pulse 1s ease-in-out infinite;
+}
+
+.dot:nth-child(2) {
+  animation-delay: 0.15s;
+}
+
+.dot:nth-child(3) {
+  animation-delay: 0.3s;
+}

--- a/src/app/[locale]/loading.tsx
+++ b/src/app/[locale]/loading.tsx
@@ -1,0 +1,13 @@
+import styles from './loading.module.css';
+
+export default function Loading() {
+  return (
+    <main className={styles.main}>
+      <div aria-label="Loading" className={styles.dots} role="status">
+        <span className={styles.dot} />
+        <span className={styles.dot} />
+        <span className={styles.dot} />
+      </div>
+    </main>
+  );
+}

--- a/src/app/[locale]/not-found.module.css
+++ b/src/app/[locale]/not-found.module.css
@@ -1,0 +1,44 @@
+.main {
+  margin: 0 auto;
+  display: flex;
+  min-height: 60vh;
+  width: 100%;
+  max-width: 80rem;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.2rem;
+  padding: 8rem 1.5rem;
+  text-align: center;
+}
+
+.title {
+  font-size: var(--text-3xl);
+  line-height: var(--line-height-3xl);
+  font-weight: 700;
+  color: var(--color-text-main);
+}
+
+.description {
+  max-width: 48rem;
+  font-size: var(--text-lg);
+  line-height: var(--line-height-lg);
+  color: var(--color-text-sub);
+}
+
+.backLink {
+  margin-top: 1.2rem;
+  border-radius: var(--radius-full);
+  background: var(--color-accent);
+  padding: 1.3rem 3rem;
+  font-size: var(--text-base);
+  line-height: var(--line-height-base);
+  font-weight: 600;
+  color: #fff;
+  transition: transform 0.2s ease, background-color 0.2s ease;
+}
+
+.backLink:hover {
+  transform: translateY(-0.05rem);
+  background-color: var(--color-accent-hover);
+}

--- a/src/app/[locale]/not-found.module.css
+++ b/src/app/[locale]/not-found.module.css
@@ -34,7 +34,7 @@
   font-size: var(--text-base);
   line-height: var(--line-height-base);
   font-weight: 600;
-  color: #fff;
+  color: var(--color-text-on-accent);
   transition: transform 0.2s ease, background-color 0.2s ease;
 }
 

--- a/src/app/[locale]/not-found.tsx
+++ b/src/app/[locale]/not-found.tsx
@@ -1,0 +1,23 @@
+import { getTranslations } from 'next-intl/server';
+
+import { Link } from '@/i18n/navigation';
+
+import styles from './not-found.module.css';
+
+export default async function NotFound() {
+  const t = await getTranslations('NotFound');
+
+  return (
+    <main className={styles.main}>
+      <h1 className={styles.title}>
+        {t('title')}
+      </h1>
+      <p className={styles.description}>
+        {t('description')}
+      </p>
+      <Link className={styles.backLink} href="/">
+        {t('backHome')}
+      </Link>
+    </main>
+  );
+}

--- a/src/app/[locale]/page.module.css
+++ b/src/app/[locale]/page.module.css
@@ -159,7 +159,7 @@
   font-size: var(--text-base);
   line-height: var(--line-height-base);
   font-weight: 600;
-  color: #fff;
+  color: var(--color-text-on-accent);
   box-shadow: var(--shadow-glow-accent);
   transition: transform 0.2s ease, background-color 0.2s ease;
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -134,5 +134,15 @@
     "challenge": "Challenge",
     "action": "Action",
     "result": "Result"
+  },
+  "NotFound": {
+    "title": "Page not found",
+    "description": "The page you're looking for doesn't exist or may have moved.",
+    "backHome": "Back to home"
+  },
+  "ErrorBoundary": {
+    "title": "Something went wrong",
+    "description": "An unexpected error occurred while loading this page.",
+    "retry": "Try again"
   }
 }

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -134,5 +134,15 @@
     "challenge": "Challenge",
     "action": "Action",
     "result": "Result"
+  },
+  "NotFound": {
+    "title": "페이지를 찾을 수 없어요",
+    "description": "요청하신 페이지가 존재하지 않거나 이동되었을 수 있어요.",
+    "backHome": "홈으로 돌아가기"
+  },
+  "ErrorBoundary": {
+    "title": "문제가 발생했어요",
+    "description": "페이지를 불러오는 중 예기치 않은 오류가 발생했어요.",
+    "retry": "다시 시도"
   }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -45,6 +45,7 @@
   --color-secondary: #1d4ed8;
   --color-accent: #22d3ee;
   --color-accent-hover: #06b6d4;
+  --color-text-on-accent: #fff;
   --color-bg-main: #060816;
   --color-surface-elevated: rgb(10 16 31 / 80%);
   --color-surface-card: rgb(11 17 32 / 95%);


### PR DESCRIPTION
## Problems :mag:

 - 페이지가 3개(`/`, `/about`, `/projects`, 상세까지 포함하면 4종)로 늘었는데 `loading.tsx`/`error.tsx`/`not-found.tsx`가 하나도 없어, 잘못된 URL이나 런타임 에러 시 Next.js 기본(스타일 없는) 화면이 그대로 노출됨 (#27)

## Causes  :bulb:

 - 라우트 구조와 공통 레이아웃만 먼저 잡고 loading/error/not-found 바운더리는 아직 추가하지 않은 상태였음

## Changes :memo:

 - `src/app/[locale]/not-found.tsx` 추가 — 잘못된 프로젝트 slug(`getProject(slug)`가 `undefined`일 때 `notFound()` 호출)나 존재하지 않는 경로 접근 시 사이트 톤에 맞는 404 + 홈으로 돌아가기 링크
 - `src/app/[locale]/error.tsx` 추가 — Client Component 에러 바운더리. Next 16.2에 새로 추가된 `unstable_retry()` 사용(공식 문서가 기존 `reset()` 대신 이걸 권장)
 - `src/app/[locale]/loading.tsx` 추가 — 번역 없는 순수 시각 로딩 인디케이터(펄스 도트 3개, 언어 무관 UI라 i18n 키 안 씀)
 - `NotFound`/`ErrorBoundary` i18n 메시지 네임스페이스 추가 (ko/en)
 - **루트 레벨(`app/not-found.tsx`, experimental `global-not-found`)은 이번엔 보류** — next-intl 미들웨어가 모든 경로를 내부적으로 `[locale]`이 붙은 경로로 rewrite하므로, `[locale]` 세그먼트에 전혀 도달 못 하는 진짜 최상위 404가 실질적으로 발생하지 않음. 판단 근거는 ADR에 기록
 - `docs/Architecture-Decision-Records.md`에 결정 사항 기록

Closes #27

## Testing :test_tube:

 - [x] `npm run tsc`
 - [x] `npm run lint`
 - [x] `npm run build` (Turbopack 경로 포함, 기존 6개 페이지 정적 생성 유지 확인)
 - [x] 브라우저에서 존재하지 않는 프로젝트 slug/경로로 404 확인, 다크/라이트 모드 모두 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 잘못된 경로 또는 프로젝트 주소 접근 시 지역화된 404 안내 화면을 제공합니다.
  - 예기치 않은 오류 발생 시 안내 메시지와 재시도 버튼을 표시합니다.
  - 페이지 전환 및 콘텐츠 로딩 중 애니메이션 기반 로딩 화면을 제공합니다.
  - 한국어와 영어 안내 문구를 지원합니다.

- **문서**
  - 라우팅 확장에 따른 로딩, 오류, 404 화면 처리 기준을 아키텍처 결정 기록에 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->