### PR TITLE
feat: add Lab page layout with demo card scaffold

### DIFF
--- a/src/app/[locale]/lab/page.module.css
+++ b/src/app/[locale]/lab/page.module.css
@@ -1,0 +1,115 @@
+.main {
+  margin: 0 auto;
+  display: flex;
+  width: 100%;
+  max-width: 80rem;
+  flex-direction: column;
+  gap: 4rem;
+  padding: 8rem 1.5rem;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.eyebrow {
+  font-size: var(--text-xs);
+  line-height: var(--line-height-xs);
+  font-weight: 500;
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--color-accent);
+}
+
+.heading {
+  font-size: var(--text-3xl);
+  line-height: var(--line-height-3xl);
+  font-weight: 700;
+  color: var(--color-text-main);
+}
+
+@media screen and (min-width: 640px) {
+  .heading {
+    font-size: var(--text-4xl);
+    line-height: var(--line-height-4xl);
+  }
+}
+
+.intro {
+  max-width: 64rem;
+  font-size: var(--text-lg);
+  line-height: var(--line-height-lg);
+  color: var(--color-text-sub);
+}
+
+.grid {
+  display: grid;
+  gap: 1.6rem;
+}
+
+@media screen and (min-width: 640px) {
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-card);
+  padding: 2.4rem;
+  box-shadow: var(--shadow-control);
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.2rem;
+}
+
+.cardTitle {
+  font-size: var(--text-lg);
+  line-height: var(--line-height-lg);
+  font-weight: 600;
+  color: var(--color-text-main);
+}
+
+.cardStatus {
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  padding: 0.2rem 0.8rem;
+  font-size: var(--text-xs);
+  line-height: var(--line-height-xs);
+  font-weight: 500;
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--color-text-sub);
+}
+
+.cardDescription {
+  font-size: var(--text-sm);
+  line-height: var(--line-height-sm);
+  color: var(--color-text-sub);
+}
+
+.tagList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+}
+
+.tag {
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--color-accent) 12%, transparent);
+  padding: 0.2rem 0.8rem;
+  font-size: var(--text-xs);
+  line-height: var(--line-height-xs);
+  font-weight: 500;
+  color: var(--color-accent);
+}

--- a/src/app/[locale]/lab/page.tsx
+++ b/src/app/[locale]/lab/page.tsx
@@ -1,0 +1,71 @@
+import type { Metadata } from 'next';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+
+import styles from './page.module.css';
+
+type Props = {
+  params: Promise<{ locale: string }>;
+};
+
+type DemoItem = {
+  title: string;
+  description: string;
+  tags: string[];
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'Lab' });
+
+  return {
+    title: t('metaTitle'),
+    description: t('metaDescription'),
+  };
+}
+
+export default async function LabPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  const t = await getTranslations('Lab');
+  const demoItems = t.raw('demos.items') as DemoItem[];
+
+  return (
+    <main className={styles.main}>
+      <header className={styles.header}>
+        <span className={styles.eyebrow}>
+          {t('eyebrow')}
+        </span>
+        <h1 className={styles.heading}>
+          {t('heading')}
+        </h1>
+        <p className={styles.intro}>
+          {t('intro')}
+        </p>
+      </header>
+      <div className={styles.grid}>
+        {demoItems.map((demo) => (
+          <div key={demo.title} className={styles.card}>
+            <div className={styles.cardHeader}>
+              <h2 className={styles.cardTitle}>
+                {demo.title}
+              </h2>
+              <span className={styles.cardStatus}>
+                {t('comingSoon')}
+              </span>
+            </div>
+            <p className={styles.cardDescription}>
+              {demo.description}
+            </p>
+            <ul className={styles.tagList}>
+              {demo.tags.map((tag) => (
+                <li key={tag} className={styles.tag}>
+                  {tag}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -12,6 +12,7 @@ export default async function Header() {
     { label: t("home"), href: "/" },
     { label: t("about"), href: "/about" },
     { label: t("projects"), href: "/projects" },
+    { label: t("lab"), href: "/lab" },
   ];
 
   return (

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -6,7 +6,8 @@
   "Header": {
     "home": "Home",
     "about": "About",
-    "projects": "Projects"
+    "projects": "Projects",
+    "lab": "Lab"
   },
   "Hero": {
     "badge": "Frontend Architect",
@@ -134,6 +135,28 @@
     "challenge": "Challenge",
     "action": "Action",
     "result": "Result"
+  },
+  "Lab": {
+    "metaTitle": "Lab",
+    "metaDescription": "Technical experiments and live demos — 3D Playground, PDF Generator.",
+    "eyebrow": "Lab",
+    "heading": "Proof that I can actually build it",
+    "intro": "Not a finished product, but a space to prove skills through experiments that actually run.",
+    "comingSoon": "In progress",
+    "demos": {
+      "items": [
+        {
+          "title": "3D Playground",
+          "description": "An interactive demo showing how position, rotation, and bounding-box math update in real time as you manipulate a 3D object with your mouse.",
+          "tags": ["Three.js", "React Three Fiber", "@sukki/lab-3d-kit"]
+        },
+        {
+          "title": "PDF Generator",
+          "description": "A demo that generates PDFs directly in the browser while visualizing font loading and multilingual rendering.",
+          "tags": ["react-pdf/renderer"]
+        }
+      ]
+    }
   },
   "NotFound": {
     "title": "Page not found",

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -6,7 +6,8 @@
   "Header": {
     "home": "홈",
     "about": "소개",
-    "projects": "프로젝트"
+    "projects": "프로젝트",
+    "lab": "Lab"
   },
   "Hero": {
     "badge": "Frontend Architect",
@@ -134,6 +135,28 @@
     "challenge": "Challenge",
     "action": "Action",
     "result": "Result"
+  },
+  "Lab": {
+    "metaTitle": "Lab",
+    "metaDescription": "기술 실험과 라이브 데모 — 3D Playground, PDF Generator.",
+    "eyebrow": "Lab",
+    "heading": "직접 만들 줄 안다는 증거",
+    "intro": "완성된 결과물이 아니라, 실제로 동작하는 실험을 통해 기술을 증명하는 공간입니다.",
+    "comingSoon": "준비 중",
+    "demos": {
+      "items": [
+        {
+          "title": "3D Playground",
+          "description": "마우스로 3D 오브젝트를 조작하면서 좌표·회전·바운딩 박스가 실시간으로 어떻게 계산되는지 보여주는 인터랙티브 데모.",
+          "tags": ["Three.js", "React Three Fiber", "@sukki/lab-3d-kit"]
+        },
+        {
+          "title": "PDF Generator",
+          "description": "브라우저에서 직접 PDF를 생성하면서 폰트 로딩 과정과 다국어 렌더링을 시각화하는 데모.",
+          "tags": ["react-pdf/renderer"]
+        }
+      ]
+    }
   },
   "NotFound": {
     "title": "페이지를 찾을 수 없어요",


### PR DESCRIPTION
## Problems :mag:

 - `/lab` 라우트가 존재하지 않아 Lab 페이지(#33)의 진입점이 없었음
 - Header 내비게이션에도 Lab 메뉴가 빠져 있었음

## Causes  :bulb:

 - 기술 실험/라이브 데모 공간으로서의 Lab 페이지가 아직 스캐폴딩조차 없던 상태 (docs/PORTFOLIO-SPEC.md 참고)
 - 3D Playground(#69), PDF Generator 등 개별 데모 구현에 앞서 페이지 레이아웃과 데모 카드 그리드 구조를 먼저 잡아둘 필요가 있었음

## Changes :memo:

 - `src/app/[locale]/lab/page.tsx` 추가: Lab 페이지 레이아웃 (eyebrow/heading/intro 헤더 + 데모 카드 그리드)
 - `src/app/[locale]/lab/page.module.css` 추가: 페이지 전용 스타일
 - `src/components/layout/Header.tsx`: 내비게이션에 Lab 메뉴 항목 추가
 - `src/messages/ko.json`, `src/messages/en.json`: `Lab` 네임스페이스(메타데이터, 헤딩, 데모 아이템 목록 등) 추가
 - 데모 카드는 아직 실제 구현 전이라 각 카드에 "Coming soon" 상태 배지로 표시

## Testing :test_tube:

 - [x] `npm run lint` / `tsc --noEmit` 통과 확인
 - [x] 브라우저에서 `/lab`, `/en/lab` 실 렌더링 및 반응형 확인 (직접 확인 예정)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 새로운 Lab 페이지가 추가되어 데모 목록을 카드 형태로 확인할 수 있습니다.
  * 3D Playground 및 PDF Generator 데모의 설명과 태그를 제공합니다.
  * 헤더 내비게이션에서 Lab 페이지로 이동할 수 있습니다.
  * 영어와 한국어 콘텐츠를 지원합니다.

* **스타일**
  * 화면 크기에 따라 조정되는 반응형 카드 그리드와 페이지 레이아웃을 적용했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->