### PR TITLE
feat: replace PDF Generator demo with HTML Report Viewer

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -4,7 +4,8 @@
     "import-notation": "string",
     "property-no-vendor-prefix": null,
     "media-feature-range-notation": "prefix",
-    "property-no-unknown": [true, { "ignoreProperties": ["composes"] }]
+    "property-no-unknown": [true, { "ignoreProperties": ["composes"] }],
+    "value-keyword-case": [ "lower", { "ignoreProperties": ["composes"] } ]
   },
   "overrides": [
     {

--- a/docs/Architecture-Decision-Records.md
+++ b/docs/Architecture-Decision-Records.md
@@ -325,3 +325,26 @@
 - 런타임 에러 발생 시에도 빈 화면이나 Next 기본 에러 페이지 대신 재시도 가능한 UI 제공
 - `error.tsx`가 Client Component라 `generateMetadata`를 못 쓰는 제약은 그대로 — 문서에서도 이 경우 React `<title>`을 직접 쓰라고 안내하지만, 지금은 에러 페이지에 별도 메타데이터가 굳이 필요하지 않아 보류
 - 향후 최상위 404 케이스가 실제로 문제된다면 `experimental.globalNotFound` 활성화 여부를 다시 검토
+
+## 🎯 2026-07-23: Lab 데모 — HTML Report Viewer (PDF Generator 계획 대체)
+
+### Context
+
+- PORTFOLIO-SPEC의 Lab 데모 2번("PDF Generator", `react-pdf/renderer` 활용)은 실제 착수 전 초안이었을 뿐, 이 프로젝트의 실제 근거가 된 Checkpoint 프로젝트(`src/content/projects/checkpoint.ts`)에서는 `@react-pdf/renderer`(HTML→이미지 캡처 방식)를 오히려 폐기하고 **HTML Report Viewer**(실제 HTML/React 렌더링 + `window.print()`/Print CSS)로 전환한 이력이 있었음
+- Lab 페이지는 "이 사람 직접 만들 줄 안다"를 증명하는 라이브 데모 공간이고, 트러블슈팅 서사 자체는 이미 Projects 케이스 스터디에 Challenge/Action/Result로 충분히 문서화돼 있어 Lab에서 다시 글로 풀어낼 필요는 없다고 판단 — 대신 실제로 채택했던 접근을 그대로 라이브 데모로 재현하는 방향으로 스펙을 변경
+
+### Decision
+
+- **데모 내용**: 실제 HTML 블록(heading/paragraph/image-placeholder)으로 렌더링된 문서를 `@dnd-kit/core` + `@dnd-kit/sortable`로 드래그 재배열, `contentEditable` 기반으로 인라인 텍스트 편집(리치 텍스트 에디터 라이브러리는 도입하지 않음 — "진짜 DOM 텍스트"라는 메시지에 필요한 범위를 넘어선다고 판단), `window.print()` + `@media print` CSS로 편집 UI를 숨기고 인쇄/PDF 출력. ko/en/ja/ar 샘플 언어 전환으로 다국어 렌더링(웹폰트라 폰트 임베딩 과정 자체가 필요 없다는 점이 react-pdf 대비 차별점) 시연
+- **라우팅**: `/lab` 그리드 카드에 인라인으로 넣기엔 인터랙션 표면이 커서, `projects/[slug]`와 동일한 "카드 → 전용 라우트" 패턴을 따라 `/lab/report-viewer` 신설. `DemoItem` 타입에 optional `href` 추가, `href`가 있는 카드만 `@/i18n/navigation`의 `Link`로 렌더링(3D Playground는 아직 `href` 없이 "준비 중" 상태 유지)
+- **`next/dynamic({ ssr: false })` 최초 도입**: Next.js 문서상 `ssr: false`는 Server Component에서 직접 호출 불가(`page.tsx`는 `getTranslations`/`setRequestLocale`을 쓰는 async Server Component). `dynamic()` 호출만 소유하는 얇은 `'use client'` 로더(`ReportViewerLoader.tsx`)를 두고 `page.tsx`는 이 로더를 평범하게 import하는 방식으로 우회 — 서브트리가 서버에서 전혀 렌더링되지 않아 dnd-kit의 `useId` 기반 aria 값이 hydration 시 서버/클라이언트로 불일치할 걱정도 함께 사라짐
+- **`src/components/features/` 디렉토리 최초 사용**: `.coderabbit.yaml`이 이미 이 경로에 대한 path instruction("비즈니스 로직은 hooks/로 분리, Server Component 우선 설계 검토")을 예고해뒀던 걸 선반영 — 상태/mutation은 컴포넌트가 아니라 `src/hooks/useReportViewerDemo.ts`에 위치
+- **순수 클라이언트 인터랙션 목적의 첫 런타임 의존성**: `@dnd-kit/core` / `@dnd-kit/sortable` / `@dnd-kit/utilities`. `KeyboardSensor`로 키보드 재배열(접근성)까지 기본 제공되는 점, `react-beautiful-dnd`는 유지보수 종료 상태인 점이 근거
+- **ESLint 설정 버그 발견 및 수정**: 구현 중 `onCommitText: (id: string, content: string) => void` 같은 함수 타입 시그니처의 파라미터명이 `no-unused-vars`(base rule)에 의해 "사용 안 함"으로 오탐되는 걸 발견 — `eslint-config-next/typescript`가 이미 TS 인식 버전(`@typescript-eslint/no-unused-vars`)을 등록해뒀는데, 프로젝트 자체 설정이 TS 문법을 모르는 base rule을 별도로 `"error"` 재등록해 충돌하고 있었음. base rule 등록을 제거해 해결
+
+### Consequences
+
+- 트러블슈팅 서사(Projects)와 라이브 데모(Lab)의 역할이 명확히 분리됨 — 앞으로 Lab에 새 데모를 추가할 때도 "글로 설명"이 아니라 "만질 수 있는 것"에 집중하는 기준으로 삼을 수 있음
+- 브라우저 전용 Lab 데모에 대한 "dynamic import + `ssr:false`로 분리" 정책이 실제 코드로 처음 확립됨 — 이후 3D Playground(`@sukki/lab-3d-kit`, #69) 통합 시에도 동일 패턴(로더 컴포넌트 경유) 재사용 가능
+- `src/components/features/` 컨벤션(컴포넌트는 뷰, 상태/로직은 `src/hooks/`)이 처음으로 실제 코드에 반영되어, 향후 CodeRabbit 리뷰가 이 경로에 대해 참조할 실제 사례가 생김
+- ESLint 설정 수정으로 이후 어떤 코드든 함수 타입 시그니처에 이름 있는 파라미터를 자유롭게 쓸 수 있게 됨(이전엔 해당 패턴을 쓰는 순간 무조건 lint 에러였음)

--- a/docs/PORTFOLIO-SPEC.md
+++ b/docs/PORTFOLIO-SPEC.md
@@ -149,11 +149,12 @@ Result     → 결과 및 임팩트
 - 바운딩 박스 시각화
 - → 별도 npm 패키지로 분리 후 install해서 사용 (엔지니어링 자산화)
 
-**② PDF Generator**
-- 브라우저에서 직접 PDF 생성
-- 폰트 로딩 과정 시각화
-- 다국어 폰트 렌더링 데모
-- → react-pdf/renderer 활용
+**② HTML Report Viewer**
+- 실제 HTML/React 블록(헤딩/문단/이미지 placeholder)으로 렌더링되는 문서
+- dnd-kit 기반 블록 드래그 재배열, contentEditable 기반 인라인 텍스트 편집
+- window.print() + Print CSS로 편집 UI를 숨기고 인쇄/PDF 출력
+- ko/en/ja/ar 샘플 언어 전환 — 폰트 임베딩 없이 즉시 렌더링되는 웹폰트 다국어 데모
+- → Checkpoint 프로젝트에서 실제로 채택한 HTML Report Viewer 접근을 재현 (react-pdf/renderer 대신)
 
 ---
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -120,9 +120,10 @@ const eslintConfig = defineConfig([
   },
 
   // ─── 코드 품질 규칙 ───────────────────────────────────────────────────────
+  // no-unused-vars는 TS 타입 문법을 이해 못 해서 타입 함수 시그니처의 파라미터명을
+  // 오탐하므로 등록하지 않음 — nextTs가 이미 @typescript-eslint/no-unused-vars를 등록함.
   {
     rules: {
-      "no-unused-vars": "error",
       "no-console": ["warn", { allow: ["warn", "error"] }],
       "no-debugger": "error",
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "polio",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "next": "16.2.10",
         "next-intl": "4.13.2",
         "next-themes": "^0.4.6",
@@ -489,6 +492,59 @@
       },
       "peerDependencies": {
         "postcss-selector-parser": "^7.1.1"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "icons": "node scripts/build-svg-sprite.mts"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "next": "16.2.10",
     "next-intl": "4.13.2",
     "next-themes": "^0.4.6",

--- a/src/app/[locale]/lab/page.module.css
+++ b/src/app/[locale]/lab/page.module.css
@@ -92,6 +92,12 @@
   color: var(--color-text-sub);
 }
 
+.cardStatusLive {
+  composes: cardStatus;
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
 .cardDescription {
   font-size: var(--text-sm);
   line-height: var(--line-height-sm);

--- a/src/app/[locale]/lab/page.tsx
+++ b/src/app/[locale]/lab/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 import { getTranslations, setRequestLocale } from 'next-intl/server';
 
+import { Link } from '@/i18n/navigation';
+
 import styles from './page.module.css';
 
 type Props = {
@@ -11,6 +13,7 @@ type DemoItem = {
   title: string;
   description: string;
   tags: string[];
+  href?: string;
 };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
@@ -43,28 +46,40 @@ export default async function LabPage({ params }: Props) {
         </p>
       </header>
       <div className={styles.grid}>
-        {demoItems.map((demo) => (
-          <div key={demo.title} className={styles.card}>
-            <div className={styles.cardHeader}>
-              <h2 className={styles.cardTitle}>
-                {demo.title}
-              </h2>
-              <span className={styles.cardStatus}>
-                {t('comingSoon')}
-              </span>
+        {demoItems.map((demo) => {
+          const cardBody = (
+            <>
+              <div className={styles.cardHeader}>
+                <h2 className={styles.cardTitle}>
+                  {demo.title}
+                </h2>
+                <span className={demo.href ? styles.cardStatusLive : styles.cardStatus}>
+                  {demo.href ? t('tryItNow') : t('comingSoon')}
+                </span>
+              </div>
+              <p className={styles.cardDescription}>
+                {demo.description}
+              </p>
+              <ul className={styles.tagList}>
+                {demo.tags.map((tag) => (
+                  <li key={tag} className={styles.tag}>
+                    {tag}
+                  </li>
+                ))}
+              </ul>
+            </>
+          );
+
+          return demo.href ? (
+            <Link key={demo.title} className={styles.card} href={demo.href}>
+              {cardBody}
+            </Link>
+          ) : (
+            <div key={demo.title} className={styles.card}>
+              {cardBody}
             </div>
-            <p className={styles.cardDescription}>
-              {demo.description}
-            </p>
-            <ul className={styles.tagList}>
-              {demo.tags.map((tag) => (
-                <li key={tag} className={styles.tag}>
-                  {tag}
-                </li>
-              ))}
-            </ul>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </main>
   );

--- a/src/app/[locale]/lab/report-viewer/page.module.css
+++ b/src/app/[locale]/lab/report-viewer/page.module.css
@@ -1,0 +1,51 @@
+.main {
+  margin: 0 auto;
+  display: flex;
+  width: 100%;
+  max-width: 80rem;
+  flex-direction: column;
+  gap: 2.4rem;
+  padding: 8rem 1.5rem;
+}
+
+.backLink {
+  font-size: var(--text-sm);
+  line-height: var(--line-height-sm);
+  color: var(--color-text-sub);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.eyebrow {
+  font-size: var(--text-xs);
+  line-height: var(--line-height-xs);
+  font-weight: 500;
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--color-accent);
+}
+
+.heading {
+  font-size: var(--text-3xl);
+  line-height: var(--line-height-3xl);
+  font-weight: 700;
+  color: var(--color-text-main);
+}
+
+@media screen and (min-width: 640px) {
+  .heading {
+    font-size: var(--text-4xl);
+    line-height: var(--line-height-4xl);
+  }
+}
+
+.intro {
+  max-width: 64rem;
+  font-size: var(--text-lg);
+  line-height: var(--line-height-lg);
+  color: var(--color-text-sub);
+}

--- a/src/app/[locale]/lab/report-viewer/page.tsx
+++ b/src/app/[locale]/lab/report-viewer/page.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from 'next';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+
+import { Link } from '@/i18n/navigation';
+import type { DemoLocale } from '@components/features/report-viewer/content';
+import ReportViewerLoader from '@components/features/report-viewer/ReportViewerLoader';
+
+import styles from './page.module.css';
+
+type Props = {
+  params: Promise<{ locale: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'Lab' });
+
+  return {
+    title: t('reportViewer.metaTitle'),
+    description: t('reportViewer.metaDescription'),
+  };
+}
+
+export default async function ReportViewerPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  const t = await getTranslations('Lab');
+  const initialLocale: DemoLocale = locale === 'ko' ? 'ko' : 'en';
+
+  return (
+    <main className={styles.main}>
+      <Link className={styles.backLink} href="/lab">
+        {t('reportViewer.backLink')}
+      </Link>
+      <header className={styles.header}>
+        <span className={styles.eyebrow}>
+          {t('reportViewer.eyebrow')}
+        </span>
+        <h1 className={styles.heading}>
+          {t('reportViewer.heading')}
+        </h1>
+        <p className={styles.intro}>
+          {t('reportViewer.intro')}
+        </p>
+      </header>
+      <ReportViewerLoader initialLocale={initialLocale} />
+    </main>
+  );
+}

--- a/src/components/common/Icon.tsx
+++ b/src/components/common/Icon.tsx
@@ -1,6 +1,6 @@
 import { SVGAttributes } from 'react';
 
-type IconName = 'moon' | 'sun';
+type IconName = 'grip' | 'moon' | 'print' | 'sun';
 
 type IconProps = {
   name: IconName;

--- a/src/components/features/report-viewer/ReportBlock.module.css
+++ b/src/components/features/report-viewer/ReportBlock.module.css
@@ -1,0 +1,77 @@
+.block {
+  display: flex;
+  align-items: flex-start;
+  gap: 1.2rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-card);
+  padding: 1.6rem;
+}
+
+.dragging {
+  composes: block;
+  box-shadow: var(--shadow-control);
+  opacity: 0.6;
+}
+
+.dragHandle {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: none;
+  padding: 0.4rem;
+  color: var(--color-text-sub);
+  cursor: grab;
+  touch-action: none;
+}
+
+.dragHandle svg {
+  width: 1.8rem;
+  height: 1.8rem;
+}
+
+.blockHeading {
+  flex: 1;
+  font-size: var(--text-xl);
+  line-height: var(--line-height-xl);
+  font-weight: 600;
+  color: var(--color-text-main);
+  outline: none;
+}
+
+.blockParagraph {
+  flex: 1;
+  font-size: var(--text-base);
+  line-height: var(--line-height-base);
+  color: var(--color-text-sub);
+  outline: none;
+}
+
+.imagePlaceholder {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  border: 1px dashed var(--color-border);
+  padding: 2.4rem;
+  font-size: var(--text-sm);
+  line-height: var(--line-height-sm);
+  color: var(--color-text-sub);
+  text-align: center;
+}
+
+@media print {
+  .block,
+  .dragging {
+    border: none;
+    background: none;
+    break-inside: avoid;
+  }
+
+  .dragHandle {
+    display: none !important;
+  }
+}

--- a/src/components/features/report-viewer/ReportBlock.tsx
+++ b/src/components/features/report-viewer/ReportBlock.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+
+import Icon from '@components/common/Icon';
+
+import type { Block } from './content';
+import styles from './ReportBlock.module.css';
+
+type ReportBlockProps = {
+  block: Block;
+  dragHandleLabel: string;
+  onCommitText: (id: string, content: string) => void;
+};
+
+export default function ReportBlock({ block, dragHandleLabel, onCommitText }: ReportBlockProps) {
+  const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable({ id: block.id });
+  const textRef = useRef<HTMLDivElement>(null);
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  useEffect(() => {
+    if (textRef.current && textRef.current.textContent !== block.content) {
+      textRef.current.textContent = block.content;
+    }
+  }, [block.content]);
+
+  return (
+    <div ref={setNodeRef} className={isDragging ? styles.dragging : styles.block} style={style}>
+      <button
+        aria-label={dragHandleLabel}
+        className={styles.dragHandle}
+        type="button"
+        {...attributes}
+        {...listeners}
+      >
+        <Icon name="grip" />
+      </button>
+      {block.type === 'image-placeholder' ? (
+        <div className={styles.imagePlaceholder}>
+          {block.content}
+        </div>
+      ) : (
+        <div
+          ref={textRef}
+          contentEditable
+          suppressContentEditableWarning
+          aria-level={block.type === 'heading' ? 2 : undefined}
+          className={block.type === 'heading' ? styles.blockHeading : styles.blockParagraph}
+          role={block.type === 'heading' ? 'heading' : undefined}
+          onBlur={(event) => onCommitText(block.id, event.currentTarget.textContent ?? '')}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/features/report-viewer/ReportViewerDemo.module.css
+++ b/src/components/features/report-viewer/ReportViewerDemo.module.css
@@ -1,0 +1,119 @@
+.demo {
+  display: flex;
+  flex-direction: column;
+  gap: 2.4rem;
+}
+
+.loadingSkeleton {
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-card);
+  height: 40rem;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.2rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-elevated);
+  padding: 1.2rem 1.6rem;
+}
+
+.languageGroup {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.languageLabel {
+  font-size: var(--text-xs);
+  line-height: var(--line-height-xs);
+  font-weight: 500;
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--color-text-sub);
+}
+
+.languageButton {
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: none;
+  padding: 0.4rem 1rem;
+  font-size: var(--text-sm);
+  line-height: var(--line-height-sm);
+  color: var(--color-text-sub);
+  cursor: pointer;
+}
+
+.languageButtonActive {
+  composes: languageButton;
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.actionGroup {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.resetButton {
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: none;
+  padding: 0.6rem 1.2rem;
+  font-size: var(--text-sm);
+  line-height: var(--line-height-sm);
+  color: var(--color-text-sub);
+  cursor: pointer;
+}
+
+.printButton {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  border-radius: var(--radius-sm);
+  border: none;
+  background: var(--color-accent);
+  padding: 0.6rem 1.2rem;
+  font-size: var(--text-sm);
+  line-height: var(--line-height-sm);
+  font-weight: 500;
+  color: var(--color-text-on-accent);
+  cursor: pointer;
+}
+
+.printButton svg {
+  width: 1.6rem;
+  height: 1.6rem;
+}
+
+.documentSurface {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-card);
+  padding: 2.4rem;
+  box-shadow: var(--shadow-control);
+}
+
+@media print {
+  .toolbar {
+    display: none !important;
+  }
+
+  .documentSurface {
+    border: none;
+    box-shadow: none;
+    background: #fff;
+    color: #000;
+    forced-color-adjust: none;
+  }
+}

--- a/src/components/features/report-viewer/ReportViewerDemo.tsx
+++ b/src/components/features/report-viewer/ReportViewerDemo.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import { sortableKeyboardCoordinates, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { useTranslations } from 'next-intl';
+
+import { useReportViewerDemo } from '@/hooks/useReportViewerDemo';
+import Icon from '@components/common/Icon';
+
+import { DEMO_LOCALES, type DemoLocale } from './content';
+import ReportBlock from './ReportBlock';
+import styles from './ReportViewerDemo.module.css';
+
+type ReportViewerDemoProps = {
+  initialLocale: DemoLocale;
+};
+
+export default function ReportViewerDemo({ initialLocale }: ReportViewerDemoProps) {
+  const t = useTranslations('ReportViewerDemo');
+  const { activeLocale, blocks, commitBlockText, reorderBlocks, resetDemo, setActiveLocale } =
+    useReportViewerDemo(initialLocale);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  function handleDragEnd({ active, over }: DragEndEvent) {
+    if (over && active.id !== over.id) {
+      reorderBlocks(String(active.id), String(over.id));
+    }
+  }
+
+  return (
+    <div className={styles.demo}>
+      <div className={styles.toolbar}>
+        <div className={styles.languageGroup}>
+          <span className={styles.languageLabel}>
+            {t('language')}
+          </span>
+          {DEMO_LOCALES.map((demoLocale) => (
+            <button
+              key={demoLocale}
+              aria-pressed={demoLocale === activeLocale}
+              className={demoLocale === activeLocale ? styles.languageButtonActive : styles.languageButton}
+              type="button"
+              onClick={() => setActiveLocale(demoLocale)}
+            >
+              {t(`languageNames.${demoLocale}`)}
+            </button>
+          ))}
+        </div>
+        <div className={styles.actionGroup}>
+          <button className={styles.resetButton} type="button" onClick={resetDemo}>
+            {t('reset')}
+          </button>
+          <button className={styles.printButton} type="button" onClick={() => window.print()}>
+            <Icon name="print" />
+            {t('print')}
+          </button>
+        </div>
+      </div>
+      <div className={styles.documentSurface} dir={activeLocale === 'ar' ? 'rtl' : 'ltr'}>
+        <DndContext collisionDetection={closestCenter} sensors={sensors} onDragEnd={handleDragEnd}>
+          <SortableContext items={blocks.map((block) => block.id)} strategy={verticalListSortingStrategy}>
+            {blocks.map((block) => (
+              <ReportBlock
+                key={block.id}
+                block={block}
+                dragHandleLabel={t('dragHandle')}
+                onCommitText={commitBlockText}
+              />
+            ))}
+          </SortableContext>
+        </DndContext>
+      </div>
+    </div>
+  );
+}

--- a/src/components/features/report-viewer/ReportViewerLoader.tsx
+++ b/src/components/features/report-viewer/ReportViewerLoader.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+import type { DemoLocale } from './content';
+import styles from './ReportViewerDemo.module.css';
+
+const ReportViewerDemo = dynamic(() => import('./ReportViewerDemo'), {
+  ssr: false,
+  loading: () => <div className={styles.loadingSkeleton} />,
+});
+
+type ReportViewerLoaderProps = {
+  initialLocale: DemoLocale;
+};
+
+export default function ReportViewerLoader({ initialLocale }: ReportViewerLoaderProps) {
+  return <ReportViewerDemo initialLocale={initialLocale} />;
+}

--- a/src/components/features/report-viewer/content.ts
+++ b/src/components/features/report-viewer/content.ts
@@ -1,0 +1,38 @@
+export type BlockType = 'heading' | 'image-placeholder' | 'paragraph';
+
+export type Block = {
+  content: string;
+  id: string;
+  type: BlockType;
+};
+
+export type DemoLocale = 'ar' | 'en' | 'ja' | 'ko';
+
+export const DEMO_LOCALES: DemoLocale[] = ['ko', 'en', 'ja', 'ar'];
+
+export const REPORT_SEED: Record<DemoLocale, Block[]> = {
+  ar: [
+    { id: 'ar-1', type: 'heading', content: 'تقرير فحص الجودة للربع الرابع 2026' },
+    { id: 'ar-2', type: 'paragraph', content: 'يلخص هذا التقرير النتائج التي تم جمعها أثناء عملية الفحص.' },
+    { id: 'ar-3', type: 'image-placeholder', content: 'التقاط صورة الفحص' },
+    { id: 'ar-4', type: 'paragraph', content: 'لم يتم العثور على أي ملاحظات غير طبيعية في جميع العناصر التي تم فحصها.' },
+  ],
+  en: [
+    { id: 'en-1', type: 'heading', content: 'Q4 2026 Quality Inspection Report' },
+    { id: 'en-2', type: 'paragraph', content: 'This report summarizes the results collected during the inspection process.' },
+    { id: 'en-3', type: 'image-placeholder', content: 'Inspection image capture' },
+    { id: 'en-4', type: 'paragraph', content: 'No anomalies were found across all inspected items.' },
+  ],
+  ja: [
+    { id: 'ja-1', type: 'heading', content: '2026年第4四半期 品質検査レポート' },
+    { id: 'ja-2', type: 'paragraph', content: '本レポートは検査工程で収集された結果をまとめたものです。' },
+    { id: 'ja-3', type: 'image-placeholder', content: '検査画像キャプチャ' },
+    { id: 'ja-4', type: 'paragraph', content: '全項目において異常所見は見つかりませんでした。' },
+  ],
+  ko: [
+    { id: 'ko-1', type: 'heading', content: '2026년 4분기 품질 검사 리포트' },
+    { id: 'ko-2', type: 'paragraph', content: '이 리포트는 검사 공정에서 수집된 결과를 요약합니다.' },
+    { id: 'ko-3', type: 'image-placeholder', content: '검사 이미지 캡처' },
+    { id: 'ko-4', type: 'paragraph', content: '전체 항목 중 이상 소견은 발견되지 않았습니다.' },
+  ],
+};

--- a/src/hooks/useReportViewerDemo.ts
+++ b/src/hooks/useReportViewerDemo.ts
@@ -1,0 +1,38 @@
+'use client';
+
+import { useState } from 'react';
+
+import { arrayMove } from '@dnd-kit/sortable';
+
+import { REPORT_SEED, type Block, type DemoLocale } from '@components/features/report-viewer/content';
+
+export function useReportViewerDemo(initialLocale: DemoLocale) {
+  const [activeLocale, setActiveLocale] = useState<DemoLocale>(initialLocale);
+  const [blocksByLocale, setBlocksByLocale] = useState<Record<DemoLocale, Block[]>>(REPORT_SEED);
+  const blocks = blocksByLocale[activeLocale];
+
+  function commitBlockText(id: string, content: string) {
+    setBlocksByLocale((prev) => ({
+      ...prev,
+      [activeLocale]: prev[activeLocale].map((block) => (block.id === id ? { ...block, content } : block)),
+    }));
+  }
+
+  function reorderBlocks(activeId: string, overId: string) {
+    setBlocksByLocale((prev) => {
+      const current = prev[activeLocale];
+      const oldIndex = current.findIndex((block) => block.id === activeId);
+      const newIndex = current.findIndex((block) => block.id === overId);
+
+      return oldIndex === -1 || newIndex === -1
+        ? prev
+        : { ...prev, [activeLocale]: arrayMove(current, oldIndex, newIndex) };
+    });
+  }
+
+  function resetDemo() {
+    setBlocksByLocale(REPORT_SEED);
+  }
+
+  return { activeLocale, blocks, commitBlockText, reorderBlocks, resetDemo, setActiveLocale };
+}

--- a/src/icons/grip.svg
+++ b/src/icons/grip.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+  <circle cx="9" cy="6" r="1" fill="currentColor" stroke="none" />
+  <circle cx="15" cy="6" r="1" fill="currentColor" stroke="none" />
+  <circle cx="9" cy="12" r="1" fill="currentColor" stroke="none" />
+  <circle cx="15" cy="12" r="1" fill="currentColor" stroke="none" />
+  <circle cx="9" cy="18" r="1" fill="currentColor" stroke="none" />
+  <circle cx="15" cy="18" r="1" fill="currentColor" stroke="none" />
+</svg>

--- a/src/icons/print.svg
+++ b/src/icons/print.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+  <path d="M6 9V3h12v6" stroke-linecap="round" stroke-linejoin="round" />
+  <rect x="6" y="13" width="12" height="8" rx="1" stroke-linejoin="round" />
+  <path d="M4 17H2.8A1.8 1.8 0 0 1 1 15.2v-3.4A1.8 1.8 0 0 1 2.8 10h18.4A1.8 1.8 0 0 1 23 11.8v3.4A1.8 1.8 0 0 1 21.2 17H20" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -138,11 +138,12 @@
   },
   "Lab": {
     "metaTitle": "Lab",
-    "metaDescription": "Technical experiments and live demos — 3D Playground, PDF Generator.",
+    "metaDescription": "Technical experiments and live demos — 3D Playground, HTML Report Viewer.",
     "eyebrow": "Lab",
     "heading": "Proof that I can actually build it",
     "intro": "Not a finished product, but a space to prove skills through experiments that actually run.",
     "comingSoon": "In progress",
+    "tryItNow": "Try it now",
     "demos": {
       "items": [
         {
@@ -151,12 +152,33 @@
           "tags": ["Three.js", "React Three Fiber", "@sukki/lab-3d-kit"]
         },
         {
-          "title": "PDF Generator",
-          "description": "A demo that generates PDFs directly in the browser while visualizing font loading and multilingual rendering.",
-          "tags": ["react-pdf/renderer"]
+          "title": "HTML Report Viewer",
+          "description": "A demo that renders a report as real HTML blocks — drag to reorder, edit inline, and print/export to PDF straight from the browser with Print CSS.",
+          "tags": ["dnd-kit", "contentEditable", "window.print()"],
+          "href": "/lab/report-viewer"
         }
       ]
+    },
+    "reportViewer": {
+      "metaTitle": "HTML Report Viewer — Lab",
+      "metaDescription": "Try block drag-reordering, inline editing, and Print CSS-based PDF output yourself.",
+      "backLink": "← Back to Lab",
+      "eyebrow": "Lab / HTML Report Viewer",
+      "heading": "A report viewer that runs entirely in the browser",
+      "intro": "Reorder a real, text-rendered document by dragging, edit it inline, then check the print preview."
     }
+  },
+  "ReportViewerDemo": {
+    "language": "Sample language",
+    "languageNames": {
+      "ko": "한국어",
+      "en": "English",
+      "ja": "日本語",
+      "ar": "العربية"
+    },
+    "dragHandle": "Drag to reorder",
+    "print": "Print / Save as PDF",
+    "reset": "Reset to initial state"
   },
   "NotFound": {
     "title": "Page not found",

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -138,11 +138,12 @@
   },
   "Lab": {
     "metaTitle": "Lab",
-    "metaDescription": "기술 실험과 라이브 데모 — 3D Playground, PDF Generator.",
+    "metaDescription": "기술 실험과 라이브 데모 — 3D Playground, HTML Report Viewer.",
     "eyebrow": "Lab",
     "heading": "직접 만들 줄 안다는 증거",
     "intro": "완성된 결과물이 아니라, 실제로 동작하는 실험을 통해 기술을 증명하는 공간입니다.",
     "comingSoon": "준비 중",
+    "tryItNow": "지금 체험하기",
     "demos": {
       "items": [
         {
@@ -151,12 +152,33 @@
           "tags": ["Three.js", "React Three Fiber", "@sukki/lab-3d-kit"]
         },
         {
-          "title": "PDF Generator",
-          "description": "브라우저에서 직접 PDF를 생성하면서 폰트 로딩 과정과 다국어 렌더링을 시각화하는 데모.",
-          "tags": ["react-pdf/renderer"]
+          "title": "HTML Report Viewer",
+          "description": "실제 HTML 블록으로 렌더링된 리포트를 드래그로 재배열하고 인라인으로 편집한 뒤, Print CSS로 그대로 인쇄/PDF 출력까지 해보는 데모.",
+          "tags": ["dnd-kit", "contentEditable", "window.print()"],
+          "href": "/lab/report-viewer"
         }
       ]
+    },
+    "reportViewer": {
+      "metaTitle": "HTML Report Viewer — Lab",
+      "metaDescription": "블록 드래그 재배열, 인라인 편집, Print CSS 기반 PDF 출력을 직접 체험하는 데모.",
+      "backLink": "← Lab으로 돌아가기",
+      "eyebrow": "Lab / HTML Report Viewer",
+      "heading": "브라우저에서 그대로 동작하는 리포트 뷰어",
+      "intro": "실제 텍스트로 렌더링된 문서를 드래그로 재배열하고 바로 수정한 뒤, 인쇄 미리보기로 확인해보세요."
     }
+  },
+  "ReportViewerDemo": {
+    "language": "샘플 언어",
+    "languageNames": {
+      "ko": "한국어",
+      "en": "English",
+      "ja": "日本語",
+      "ar": "العربية"
+    },
+    "dragHandle": "드래그해서 순서 바꾸기",
+    "print": "인쇄 / PDF로 저장",
+    "reset": "초기 상태로 되돌리기"
   },
   "NotFound": {
     "title": "페이지를 찾을 수 없어요",


### PR DESCRIPTION
## Problems

- **`/lab`에 살아있는 데모가 하나도 없음** — 카드 2개가 모두 "준비 중" 상태라, "이 사람 직접 만들 줄 안다를 체험으로 증명한다"는 Lab 페이지의 존재 목적을 아직 수행하지 못하고 있었음
- **스펙에 적힌 데모②가 실제 경험과 어긋남** — `docs/PORTFOLIO-SPEC.md`의 데모②는 "PDF Generator (`react-pdf/renderer`)"였는데, 이 프로젝트의 근거가 된 Checkpoint(`src/content/projects/checkpoint.ts`)에서는 `@react-pdf/renderer`를 **오히려 폐기하고** HTML Report Viewer로 전환한 이력이 있음. 그대로 구현하면 실제로 기각한 접근을 대표작으로 전시하게 됨
- **함수 타입 시그니처에 이름 있는 파라미터를 쓰면 무조건 lint 에러** — `onCommitText: (id: string, content: string) => void` 같은 코드가 `no-unused-vars`에 "사용 안 함"으로 걸림
- **CSS Modules의 `composes` 값이 stylelint에 걸림** — camelCase 클래스명을 `composes`로 확장하면 `value-keyword-case`가 소문자 키워드로 강제

## Causes

- 스펙의 Lab 데모 항목은 실제 착수 전에 작성된 초안이었고, 착수 시점에 실제 프로젝트 이력과 교차 검증되지 않았음
- `no-unused-vars`(base rule)는 TS 문법을 이해하지 못함. `eslint-config-next/typescript`가 이미 TS 인식 버전(`@typescript-eslint/no-unused-vars`)을 등록해두는데, 프로젝트 자체 설정이 base rule을 별도로 `"error"`로 **재등록**해서 충돌하고 있었음
- `composes`는 CSS Modules 전용 속성이라 stylelint가 그 값을 일반 CSS 키워드로 간주함 (`property-no-unknown`은 이미 예외 처리되어 있었지만 `value-keyword-case`는 누락)
- `@media print` 블록에서 인쇄 시 배경/글자색 유지를 의도했으나, 강제 색상 모드(Windows 고대비)용 속성인 `forced-color-adjust`를 사용해 실제로는 아무 효과가 없었음

## Changes

**Lab 데모② 스펙 변경 및 구현 (`Refs #33`)**

- `docs/PORTFOLIO-SPEC.md` 데모②를 **HTML Report Viewer**로 교체, `docs/Architecture-Decision-Records.md`에 결정 배경·근거·영향 기록
- `/lab/report-viewer` 라우트 신설 — 인터랙션 표면이 커서 `/lab` 그리드 카드 인라인이 아니라 `projects/[slug]`와 동일한 "카드 → 전용 라우트" 패턴을 따름. `DemoItem`에 optional `href`를 추가해 `href`가 있는 카드만 `Link`로 렌더링(3D Playground는 `href` 없이 "준비 중" 유지)
- 데모 기능
  - `@dnd-kit/core` + `@dnd-kit/sortable`로 블록(heading / paragraph / image-placeholder) 드래그 재배열. `KeyboardSensor`로 키보드 재배열도 지원
  - `contentEditable` 기반 인라인 텍스트 편집 — 리치 텍스트 에디터 라이브러리는 도입하지 않음("진짜 DOM 텍스트"라는 메시지에 필요한 범위를 넘어섬)
  - `window.print()` + `@media print`로 편집 UI(툴바·드래그 핸들)를 숨기고 인쇄/PDF 출력
  - ko / en / ja / ar 샘플 언어 전환 — 웹폰트라 폰트 임베딩 과정 자체가 없다는 점이 `react-pdf` 대비 차별점. ar은 `dir="rtl"` 적용
- **`next/dynamic({ ssr: false })` 최초 도입** — `ssr: false`는 Server Component에서 직접 호출할 수 없어(`page.tsx`는 `getTranslations`/`setRequestLocale`을 쓰는 async Server Component), `dynamic()` 호출만 소유하는 얇은 `'use client'` 로더(`ReportViewerLoader.tsx`)를 두고 `page.tsx`는 이를 평범하게 import. 서브트리가 서버에서 전혀 렌더링되지 않으므로 dnd-kit의 `useId` 기반 aria 값이 hydration에서 불일치할 여지도 함께 사라짐
- **`src/components/features/` 디렉토리 최초 사용** — `.coderabbit.yaml`이 이 경로에 예고해둔 규칙(비즈니스 로직은 `hooks/`로 분리)을 선반영해, 상태와 mutation은 컴포넌트가 아니라 `src/hooks/useReportViewerDemo.ts`에 위치
- 아이콘 `grip` / `print` 추가, `ko.json` / `en.json`에 `Lab.reportViewer` · `ReportViewerDemo` 네임스페이스 추가

**린트 설정 수정**

- `eslint.config.mjs`에서 `no-unused-vars` base rule 등록 제거 (제거 이유를 주석으로 명시)
- `.stylelintrc.json`의 `value-keyword-case`에 `ignoreProperties: ["composes"]` 추가

**접근성 · 인쇄 정확성 수정**

- `forced-color-adjust: none` → `print-color-adjust: exact` (+ Safari용 `-webkit-` 접두사 버전)
- 드래그 핸들에 `useSortable`의 `setActivatorNodeRef` 연결 — dnd-kit이 활성 요소를 정확히 인식하도록
- 문서 영역에 `lang={activeLocale}` 추가 — `dir`만으로는 폰트 폴백과 스크린리더 발음 선택이 샘플 언어를 따라가지 않음

## Test

**정적 분석 · 빌드 (로컬, CI와 동일 항목)**

| 항목 | 결과 |
|---|---|
| `npx eslint` | ✅ pass |
| `npm run stylelint` | ✅ pass |
| `npm run tsc` | ✅ pass |
| `npm run build` | ✅ pass |

- `npm run build` 로그에서 신규 라우트가 `● /[locale]/lab/report-viewer` (`/ko`, `/en` 각각)로 잡히는 것 확인 — `setRequestLocale` 누락으로 동적 렌더링(`ƒ`)으로 강등되지 않았음
- 린트 설정 수정이 기존 코드에 회귀를 만들지 않는지 전체 `eslint` / `stylelint` 재실행으로 확인

**리뷰 시 브라우저에서 직접 확인이 필요한 항목**

- [ ] 블록 드래그 재배열 (포인터 / 키보드 `Tab` → `Space` → 방향키 양쪽)
- [ ] 인라인 편집 후 blur → 내용 유지, `Reset`으로 초기 상태 복귀
- [ ] 인쇄 미리보기에서 툴바·드래그 핸들이 사라지고 배경/글자색이 유지되는지 (Chrome / **Safari** 각각 — 접두사 버전 동작 확인 목적)
- [ ] ko / en / ja / ar 전환 시 폰트 렌더링과 ar의 RTL 레이아웃
- [ ] 다크 / 라이트 테마 양쪽에서 문서 표면과 툴바 대비

---

`Refs #33` — Lab 페이지 이슈는 데모①(3D Playground, #69)이 남아 있어 이 PR로 닫히지 않습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * Lab에 HTML Report Viewer 데모를 추가했습니다.
  * 문서 블록을 드래그해 순서를 변경하고, 제목과 본문을 직접 편집할 수 있습니다.
  * 한국어, 영어, 일본어, 아랍어 샘플을 전환할 수 있습니다.
  * 데모를 초기화하거나 인쇄/PDF 출력할 수 있습니다.
  * Lab 화면에서 사용 가능한 데모는 “Try it now” 상태로 바로 열 수 있습니다.

* **문서**
  * HTML Report Viewer의 사용 방식과 채택 배경을 관련 문서에 반영했습니다.

* **스타일**
  * 인쇄 시 편집 도구와 불필요한 UI가 숨겨져 문서 출력이 깔끔해집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->